### PR TITLE
Table scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 ## [Unreleased][Unreleased]
 ### Added
 - [Feature] Add a license to the repository. (#125)
+- [Feature] Adding scrolling variation for tables.
 
 ### Fixed
 - [Patch] Fix incorrect links in the changelog.

--- a/src/core/partials/base/_tables.scss
+++ b/src/core/partials/base/_tables.scss
@@ -284,7 +284,7 @@
 }
 
 // Scrolling Tables
-// Uses two tables, one for the header and one for the body.
+// Uses flexbox to change the default behavior of the table elements.
 
 // - The parents of `table-scroll` MUST be `display:flex`.
 // - All `<th>` and `<td>` elements must have matching widths.
@@ -292,14 +292,14 @@
 // <table class="table table--scroll table--rule">
 //   <thead>
 //     <tr>
-//       <th class="width--1-2">one</th>
+//       <th class="width--2-4">one</th>
 //       <th class="width--1-4">two</th>
 //       <th class="width--1-4">three</th>
 //     </tr>
 //   </thead>
 //   <tbody>
 //     <tr>
-//       <td class="width--1-2">one</td>
+//       <td class="width--2-4">one</td>
 //       <td class="width--1-4">two</td>
 //       <td class="width--1-4">three</td>
 //     </tr>

--- a/src/core/partials/base/_tables.scss
+++ b/src/core/partials/base/_tables.scss
@@ -287,7 +287,7 @@
 // Uses two tables, one for the header and one for the body.
 
 // - The parents of `table-scroll` MUST be `display:flex`.
-// - Both `<th>` and `<td>` elements must have matching widths.
+// - All `<th>` and `<td>` elements must have matching widths.
 
 // <table class="table table--scroll table--rule">
 //   <thead>

--- a/src/core/partials/base/_tables.scss
+++ b/src/core/partials/base/_tables.scss
@@ -289,52 +289,23 @@
 // - The parents of `table-scroll` MUST be `display:flex`.
 // - Both `<th>` and `<td>` elements must have matching widths.
 
-// <div class="table-scroll">
-//   <div class="table-scroll__head-wrap">
-//     <div class="table-scroll__head">
-//       <table class="table table--rule">
-//         <thead>
-//           <tr>
-//             <th class="width--1-4">one</th>
-//             <th class="width--2-4">two</th>
-//             <th class="width--2-4">three</th>
-//           </tr>
-//         </thead>
-//       </table>
-//     </div>
-//   </div>
-//   <div class="table-scroll__body">
-//     <table class="table table--rule">
-//       <tbody>
-//         <tr>
-//           <td class="width--1-4">one</td>
-//           <td class="width--2-4">two</td>
-//           <td class="width--2-4">three</td>
-//         </tr>
-//         <tr>
-//           <td>one</td>
-//           <td>two</td>
-//           <td>three</td>
-//         </tr>
-//         <tr>
-//           <td>one</td>
-//           <td>two</td>
-//           <td>three</td>
-//         </tr>
-//         <tr>
-//           <td>one</td>
-//           <td>two</td>
-//           <td>three</td>
-//         </tr>
-//         <tr>
-//           <td>one</td>
-//           <td>two</td>
-//           <td>three</td>
-//         </tr>
-//       </tbody>
-//     </table>
-//   </div>
-// </div>
+// <table class="table table--scroll table--rule">
+//   <thead>
+//     <tr>
+//       <th class="width--1-2">one</th>
+//       <th class="width--1-4">two</th>
+//       <th class="width--1-4">three</th>
+//     </tr>
+//   </thead>
+//   <tbody>
+//     <tr>
+//       <td class="width--1-2">one</td>
+//       <td class="width--1-4">two</td>
+//       <td class="width--1-4">three</td>
+//     </tr>
+//   </tbody>
+// </table>
+
 
 .#{$namespace}table--scroll {
   @include display(flex);
@@ -353,18 +324,17 @@
     width: 100%;
     overflow-y: auto;
     min-height: 0;
-    -ms-overflow-style: -ms-autohiding-scrollbar;
+    -ms-overflow-style: -ms-autohiding-scrollbar; // Shows/hides scroll bar on Windows.
   }
 
   tr {
-    @include display(flex);
+    @include display(flex); // All table rows changed to flexbox.
     @include flex(none);
     width: 100%;
   }
 
   th,
   td {
-    @include flex(1);
     display: block;
   }
 }

--- a/src/core/partials/base/_tables.scss
+++ b/src/core/partials/base/_tables.scss
@@ -282,3 +282,89 @@
 .#{$namespace}table-row--active {
   background-color: map-fetch($color, background faint);
 }
+
+// Scrolling Tables
+// Uses two tables, one for the header and one for the body.
+
+// - The parents of `table-scroll` MUST be `display:flex`.
+// - Both `<th>` and `<td>` elements must have matching widths.
+
+// <div class="table-scroll">
+//   <div class="table-scroll__head-wrap">
+//     <div class="table-scroll__head">
+//       <table class="table table--rule">
+//         <thead>
+//           <tr>
+//             <th class="width--1-4">one</th>
+//             <th class="width--2-4">two</th>
+//             <th class="width--2-4">three</th>
+//           </tr>
+//         </thead>
+//       </table>
+//     </div>
+//   </div>
+//   <div class="table-scroll__body">
+//     <table class="table table--rule">
+//       <tbody>
+//         <tr>
+//           <td class="width--1-4">one</td>
+//           <td class="width--2-4">two</td>
+//           <td class="width--2-4">three</td>
+//         </tr>
+//         <tr>
+//           <td>one</td>
+//           <td>two</td>
+//           <td>three</td>
+//         </tr>
+//         <tr>
+//           <td>one</td>
+//           <td>two</td>
+//           <td>three</td>
+//         </tr>
+//         <tr>
+//           <td>one</td>
+//           <td>two</td>
+//           <td>three</td>
+//         </tr>
+//         <tr>
+//           <td>one</td>
+//           <td>two</td>
+//           <td>three</td>
+//         </tr>
+//       </tbody>
+//     </table>
+//   </div>
+// </div>
+
+.#{$namespace}table--scroll {
+  @include display(flex);
+  @include flex-direction(column);
+  width: 100%;
+
+  thead {
+    @include display(flex);
+    @include flex(none);
+  }
+
+  tbody {
+    @include display(flex);
+    @include flex-direction(column);
+    @include flex(1);
+    width: 100%;
+    overflow-y: auto;
+    min-height: 0;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+  }
+
+  tr {
+    @include display(flex);
+    @include flex(none);
+    width: 100%;
+  }
+
+  th,
+  td {
+    @include flex(1);
+    display: block;
+  }
+}

--- a/tests/index.html
+++ b/tests/index.html
@@ -14,6 +14,7 @@
     <ul>
       <li><a href="buttons.html">Buttons</a></li>
       <li><a href="matrix.html">Matrix</a></li>
+      <li><a href="table-scroll.html">Table Scroll</a></li>
     </ul>
   </div>
 

--- a/tests/table-scroll.html
+++ b/tests/table-scroll.html
@@ -32,8 +32,6 @@
           var rowWidth = $(this).find("tbody tr:first-child").width();
           var diff = tableWidth - rowWidth;
 
-          console.log(diff);
-
           if ( diff > 0 ) {
             $(this).find("thead tr:last-child").css("padding-right", diff);
           }

--- a/tests/table-scroll.html
+++ b/tests/table-scroll.html
@@ -15,115 +15,121 @@
       display: flex;
     }
 
-    .width--1-4 {
-      max-width: 25%;
-    }
-    .width--2-4 {
-      max-width: 50%;
-    }
-
-
   </style>
+
+  <script src="//code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>
+
+  <script>
+
+    $(document).ready(function(){
+
+
+      function setOverflowScroll() {
+
+        $(".table--scroll").each(function(){
+
+          var tableWidth =  $(this).width();
+          var rowWidth = $(this).find("tbody tr:first-child").width();
+          var diff = tableWidth - rowWidth;
+
+          console.log(diff);
+
+          if ( diff > 0 ) {
+            $(this).find("thead tr:last-child").css("padding-right", diff);
+          }
+        })
+      }
+
+      setOverflowScroll();
+
+    });
+
+
+  </script>
+
+
 </head>
 <body class="push-quad">
 
-  <div class="page-element">
 
+  <div class="page-element">
     <table class="table table--scroll table--rule">
       <thead>
         <tr>
-          <th class="width--1-4">one</th>
-          <th class="width--2-4">two</th>
+          <th class="width--1-2">one</th>
+          <th class="width--1-4">two</th>
           <th class="width--1-4">three</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td class="width--1-4">
-            Lorem ipsum dolor sit labore rerum. Perspiciatis voluptate cupiditate quia.
-            Lorem ipsum dolor sit labore rerum. Perspiciatis voluptate cupiditate quia.
-
-          </td>
-          <td class="width--2-4">
-            Lorem ipsum dolor sit labore rerum. Perspiciatis voluptate cupiditate quia.
-            Lorem ipsum dolor sit labore rerum. Perspiciatis voluptate cupiditate quia.
-          </td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
         <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
         <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
         <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
         <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
         <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
         <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
         <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
         <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
         <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
-          <td class="width--1-4">three</td>
-        </tr>
-      </tbody>
-    </table>
-
-  </div>
-
-  <div class="page-element">
-
-    <table class="table table--scroll table--rule">
-      <thead>
-        <tr>
-          <th class="width--1-4">one</th>
-          <th class="width--2-4">two</th>
-          <th class="width--1-4">three</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
         <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
         <tr>
-          <td class="width--1-4">one</td>
-          <td class="width--2-4">two</td>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-2">one</td>
+          <td class="width--1-4">two</td>
           <td class="width--1-4">three</td>
         </tr>
       </tbody>

--- a/tests/table-scroll.html
+++ b/tests/table-scroll.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Table Scroll</title>
+  <link rel="stylesheet" href="../dist/css/core.css">
+
+  <style>
+    .page-element {
+      height: 300px;
+      border: 1px solid red;
+      margin-bottom: 50px;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+    }
+
+    .width--1-4 {
+      max-width: 25%;
+    }
+    .width--2-4 {
+      max-width: 50%;
+    }
+
+
+  </style>
+</head>
+<body class="push-quad">
+
+  <div class="page-element">
+
+    <table class="table table--scroll table--rule">
+      <thead>
+        <tr>
+          <th class="width--1-4">one</th>
+          <th class="width--2-4">two</th>
+          <th class="width--1-4">three</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="width--1-4">
+            Lorem ipsum dolor sit labore rerum. Perspiciatis voluptate cupiditate quia.
+            Lorem ipsum dolor sit labore rerum. Perspiciatis voluptate cupiditate quia.
+
+          </td>
+          <td class="width--2-4">
+            Lorem ipsum dolor sit labore rerum. Perspiciatis voluptate cupiditate quia.
+            Lorem ipsum dolor sit labore rerum. Perspiciatis voluptate cupiditate quia.
+          </td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+  <div class="page-element">
+
+    <table class="table table--scroll table--rule">
+      <thead>
+        <tr>
+          <th class="width--1-4">one</th>
+          <th class="width--2-4">two</th>
+          <th class="width--1-4">three</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+        <tr>
+          <td class="width--1-4">one</td>
+          <td class="width--2-4">two</td>
+          <td class="width--1-4">three</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+
+
+</body>
+</html>


### PR DESCRIPTION
@tscanlin @kwalker3690 @danoc 

Opening PR for discussion, don't merge quite yet. :)

This version of the table scrollable is the cleanest I've come up with. But the downsides are:

- It requires JS to test for "always on" scroll bars in OS X. This could be done once and stored in cookie...? This appears to be unavoidable, regardless of implementation.
- Changes the default behavior of the table completely, converting to flexbox. No specific concern here other than it could lead to unknown bugs or unexpected behavior.
- Requires a width on all `th` and `td` elements. 

This is the cleanest implementation I could come up with but it makes me mildly nervous. Do we want to proceed? 