### PR TITLE
Lock down version of node-sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 ### Added
 - [Feature] Add a license to the repository. (#125)
 - [Feature] Adding scrolling variation for tables.
+- [Feature] Adding `shrinkwrap` file to lock down `node-sass` version used by `gulp-sass`.
 
 ### Fixed
 - [Patch] Fix incorrect links in the changelog.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,6 @@ var bump        = require('gulp-bump'),
     scsslint    = require('gulp-scss-lint'),
     symlink     = require('gulp-symlink'),
     sass        = require('gulp-sass'),
-    shrinkwrap  = require('gulp-shrinkwrap'),
     path        = require("path"),
     tagVersion  = require('gulp-tag-version');
 
@@ -24,13 +23,6 @@ var paths = {
   css: './dist/css/',
   core: './src/core/core.scss'
 };
-
-// Shrinkwrap locks down dependencies. See https://docs.npmjs.com/cli/shrinkwrap
-gulp.task('shrinkwrap', function () {
-  return gulp.src('package.json')
-    .pipe(shrinkwrap())      // just like running `npm shrinkwrap`
-    .pipe(gulp.dest('./'));  // writes newly created `npm-shrinkwrap.json` to the location of your choice
-});
 
 // Bumping version number and tagging the repository with it.
 // Please read http://semver.org/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var bump        = require('gulp-bump'),
     scsslint    = require('gulp-scss-lint'),
     symlink     = require('gulp-symlink'),
     sass        = require('gulp-sass'),
+    shrinkwrap  = require('gulp-shrinkwrap'),
     path        = require("path"),
     tagVersion  = require('gulp-tag-version');
 
@@ -24,6 +25,12 @@ var paths = {
   core: './src/core/core.scss'
 };
 
+// Shrinkwrap locks down dependencies. See https://docs.npmjs.com/cli/shrinkwrap
+gulp.task('shrinkwrap', function () {
+  return gulp.src('package.json')
+    .pipe(shrinkwrap())      // just like running `npm shrinkwrap`
+    .pipe(gulp.dest('./'));  // writes newly created `npm-shrinkwrap.json` to the location of your choice
+});
 
 // Bumping version number and tagging the repository with it.
 // Please read http://semver.org/

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "gulp-sass": {
       "version": "2.1.0",
-      "from": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-2.1.0.tgz",
+      "from": "gulp-sass@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-2.1.0.tgz",
       "dependencies": {
         "gulp-util": {
@@ -149,7 +149,7 @@
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
@@ -166,7 +166,7 @@
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
@@ -546,88 +546,88 @@
         },
         "node-sass": {
           "version": "3.3.3",
-          "from": "https://registry.npmjs.org/node-sass/-/node-sass-3.3.3.tgz",
+          "from": "node-sass@3.3.3",
           "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.3.3.tgz",
           "dependencies": {
             "async-foreach": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+              "from": "async-foreach@>=0.1.3 <0.2.0",
               "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
             },
             "chalk": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "cross-spawn": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.0.0.tgz",
+              "from": "cross-spawn@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.0.0.tgz",
               "dependencies": {
                 "cross-spawn-async": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.0.0.tgz",
+                  "from": "cross-spawn-async@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.0.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
+                      "from": "lru-cache@>=2.6.5 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                     },
                     "which": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+                      "from": "which@>=1.1.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
                       "dependencies": {
                         "is-absolute": {
                           "version": "0.1.7",
-                          "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                          "from": "is-absolute@>=0.1.7 <0.2.0",
                           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                           "dependencies": {
                             "is-relative": {
                               "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                              "from": "is-relative@>=0.1.0 <0.2.0",
                               "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                             }
                           }
@@ -638,52 +638,52 @@
                 },
                 "spawn-sync": {
                   "version": "1.0.13",
-                  "from": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz",
+                  "from": "spawn-sync@>=1.0.13 <2.0.0",
                   "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz",
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.5.1",
-                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                      "from": "concat-stream@>=1.4.7 <2.0.0",
                       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "typedarray": {
                           "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "from": "typedarray@>=0.0.5 <0.1.0",
                           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
                           "version": "2.0.3",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
+                          "from": "readable-stream@>=2.0.0 <2.1.0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "isarray@0.0.1",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "process-nextick-args": {
                               "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                              "from": "process-nextick-args@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "util-deprecate": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
                               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                             }
                           }
@@ -692,7 +692,7 @@
                     },
                     "os-shim": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+                      "from": "os-shim@>=0.1.2 <0.2.0",
                       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
                     }
                   }
@@ -701,49 +701,49 @@
             },
             "gaze": {
               "version": "0.5.2",
-              "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+              "from": "gaze@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
               "dependencies": {
                 "globule": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                  "from": "globule@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                      "from": "lodash@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                     },
                     "glob": {
                       "version": "3.1.21",
-                      "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "from": "glob@>=3.1.21 <3.2.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "1.2.3",
-                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                          "from": "graceful-fs@>=1.2.0 <1.3.0",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                         },
                         "inherits": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+                          "from": "inherits@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.7.0",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
@@ -754,49 +754,49 @@
             },
             "get-stdin": {
               "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "glob": {
               "version": "5.0.15",
-              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "from": "glob@>=5.0.14 <6.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.1",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -805,112 +805,112 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "meow": {
               "version": "3.4.2",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
+              "from": "meow@>=3.3.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "loud-rejection": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
+                  "from": "loud-rejection@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz"
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "from": "minimist@>=1.1.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.4",
-                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
+                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
-                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+                      "from": "hosted-git-info@>=2.0.2 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+                          "from": "builtin-modules@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.0.3",
-                      "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "from": "spdx-correct@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
+                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
+                              "from": "spdx-exceptions@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz"
                             },
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
@@ -921,27 +921,27 @@
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
+                      "from": "find-up@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
+                          "from": "path-exists@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                          "from": "pinkie-promise@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                              "from": "pinkie@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                             }
                           }
@@ -950,56 +950,56 @@
                     },
                     "read-pkg": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "from": "read-pkg@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
+                          "from": "load-json-file@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
-                              "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                              "from": "parse-json@>=2.2.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.2.0",
-                                  "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz",
+                                  "from": "error-ex@>=1.2.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz"
                                 }
                               }
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "from": "pify@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                                  "from": "pinkie@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "from": "strip-bom@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.0",
-                                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                                  "from": "is-utf8@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                                 }
                               }
@@ -1008,27 +1008,27 @@
                         },
                         "path-type": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
+                          "from": "path-type@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "from": "pify@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                                  "from": "pinkie@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                 }
                               }
@@ -1041,27 +1041,27 @@
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                  "from": "redent@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                      "from": "indent-string@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                          "from": "repeating@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -1072,172 +1072,172 @@
                     },
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                      "from": "strip-indent@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                  "from": "trim-newlines@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "from": "mkdirp@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "nan": {
               "version": "2.1.0",
-              "from": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz",
+              "from": "nan@>=2.0.8 <3.0.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
             },
             "npmconf": {
               "version": "2.1.2",
-              "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+              "from": "npmconf@>=2.1.2 <3.0.0",
               "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
               "dependencies": {
                 "config-chain": {
                   "version": "1.1.9",
-                  "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
                   "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
                   "dependencies": {
                     "proto-list": {
                       "version": "1.2.4",
-                      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                      "from": "proto-list@>=1.2.1 <1.3.0",
                       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                  "from": "ini@>=1.2.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "nopt": {
                   "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                  "from": "nopt@>=3.0.1 <3.1.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "from": "osenv@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                      "from": "os-homedir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "semver": {
                   "version": "4.3.6",
-                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 },
                 "uid-number": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+                  "from": "uid-number@0.0.5",
                   "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
                 }
               }
             },
             "node-gyp": {
               "version": "3.0.3",
-              "from": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.0.3.tgz",
+              "from": "node-gyp@>=3.0.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.0.3.tgz",
               "dependencies": {
                 "fstream": {
                   "version": "1.0.8",
-                  "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+                  "from": "fstream@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "glob": {
                   "version": "4.5.3",
-                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "from": "glob@>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.2.1",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "from": "concat-map@0.0.1",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -1246,12 +1246,12 @@
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -1260,81 +1260,81 @@
                 },
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                 },
                 "minimatch": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "from": "minimatch@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "nopt": {
                   "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                  "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "npmlog": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+                  "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
                   "dependencies": {
                     "ansi": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
+                      "from": "ansi@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                     },
                     "are-we-there-yet": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                       "dependencies": {
                         "delegates": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+                          "from": "delegates@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
                         },
                         "readable-stream": {
                           "version": "1.1.13",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "from": "readable-stream@>=1.1.13 <2.0.0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "isarray@0.0.1",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "from": "inherits@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -1343,32 +1343,32 @@
                     },
                     "gauge": {
                       "version": "1.2.2",
-                      "from": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+                      "from": "gauge@>=1.2.0 <1.3.0",
                       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
                       "dependencies": {
                         "has-unicode": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz",
+                          "from": "has-unicode@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
                         },
                         "lodash.pad": {
                           "version": "3.1.1",
-                          "from": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+                          "from": "lodash.pad@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
                           "dependencies": {
                             "lodash._basetostring": {
                               "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                             },
                             "lodash._createpadding": {
                               "version": "3.6.1",
-                              "from": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
                               "dependencies": {
                                 "lodash.repeat": {
                                   "version": "3.0.1",
-                                  "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
                                 }
                               }
@@ -1377,22 +1377,22 @@
                         },
                         "lodash.padleft": {
                           "version": "3.1.1",
-                          "from": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                          "from": "lodash.padleft@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
                           "dependencies": {
                             "lodash._basetostring": {
                               "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                             },
                             "lodash._createpadding": {
                               "version": "3.6.1",
-                              "from": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
                               "dependencies": {
                                 "lodash.repeat": {
                                   "version": "3.0.1",
-                                  "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
                                 }
                               }
@@ -1401,22 +1401,22 @@
                         },
                         "lodash.padright": {
                           "version": "3.1.1",
-                          "from": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                          "from": "lodash.padright@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
                           "dependencies": {
                             "lodash._basetostring": {
                               "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                             },
                             "lodash._createpadding": {
                               "version": "3.6.1",
-                              "from": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
                               "dependencies": {
                                 "lodash.repeat": {
                                   "version": "3.0.1",
-                                  "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
                                 }
                               }
@@ -1429,39 +1429,39 @@
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "from": "osenv@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                      "from": "os-homedir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "path-array": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/path-array/-/path-array-1.0.0.tgz",
+                  "from": "path-array@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.0.tgz",
                   "dependencies": {
                     "array-index": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/array-index/-/array-index-0.1.1.tgz",
+                      "from": "array-index@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/array-index/-/array-index-0.1.1.tgz",
                       "dependencies": {
                         "debug": {
                           "version": "2.2.0",
-                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "from": "debug@*",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "from": "ms@0.7.1",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
@@ -1472,49 +1472,49 @@
                 },
                 "rimraf": {
                   "version": "2.4.3",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+                  "from": "rimraf@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "5.0.15",
-                      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "from": "glob@>=5.0.14 <6.0.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
-                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "from": "inflight@>=1.0.4 <2.0.0",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "minimatch": {
                           "version": "3.0.0",
-                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.1",
-                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.2.1",
-                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
+                                  "from": "balanced-match@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "from": "concat-map@0.0.1",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
@@ -1523,19 +1523,19 @@
                         },
                         "once": {
                           "version": "1.3.2",
-                          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "from": "once@>=1.3.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                         }
                       }
@@ -1544,39 +1544,39 @@
                 },
                 "semver": {
                   "version": "5.0.3",
-                  "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
                 },
                 "tar": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+                  "from": "tar@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
                   "dependencies": {
                     "block-stream": {
                       "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+                      "from": "block-stream@*",
                       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "which": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+                  "from": "which@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
                   "dependencies": {
                     "is-absolute": {
                       "version": "0.1.7",
-                      "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                      "from": "is-absolute@>=0.1.7 <0.2.0",
                       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                       "dependencies": {
                         "is-relative": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                          "from": "is-relative@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                         }
                       }
@@ -1587,47 +1587,47 @@
             },
             "request": {
               "version": "2.65.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
+              "from": "request@>=2.61.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                  "from": "bl@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.3",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -1636,208 +1636,208 @@
                 },
                 "caseless": {
                   "version": "0.11.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                  "from": "caseless@>=0.11.0 <0.12.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                  "from": "extend@>=3.0.0 <3.1.0",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "from": "forever-agent@>=0.6.1 <0.7.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "1.0.0-rc3",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                  "from": "form-data@>=1.0.0-rc3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "1.5.0",
-                      "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+                      "from": "async@>=1.4.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "from": "json-stringify-safe@>=5.0.1 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.7",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "from": "mime-types@>=2.1.7 <2.2.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.19.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
+                      "from": "mime-db@>=1.19.0 <1.20.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "from": "node-uuid@>=1.4.3 <1.5.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "5.2.0",
-                  "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+                  "from": "qs@>=5.2.0 <5.3.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+                  "from": "tunnel-agent@>=0.4.1 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
+                  "from": "tough-cookie@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.11.0",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                  "from": "http-signature@>=0.11.0 <0.12.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "from": "ctype@0.5.3",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.8.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+                  "from": "oauth-sign@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                 },
                 "hawk": {
                   "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                  "from": "hawk@>=3.1.0 <3.2.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.16.3",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "from": "hoek@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "boom": {
                       "version": "2.10.0",
-                      "from": "https://registry.npmjs.org/boom/-/boom-2.10.0.tgz",
+                      "from": "boom@>=2.8.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "from": "sntp@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "from": "aws-sign2@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "from": "combined-stream@>=1.0.5 <1.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "from": "isstream@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
+                  "from": "har-validator@>=2.0.2 <2.1.0",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.9.0",
-                      "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "from": "commander@>=2.8.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "from": "graceful-readlink@>=1.0.0",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.12.2",
-                      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+                      "from": "is-my-json-valid@>=2.12.2 <3.0.0",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "from": "generate-function@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "from": "is-property@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                          "from": "jsonpointer@2.0.0",
                           "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                         },
                         "xtend": {
                           "version": "4.0.0",
-                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                          "from": "xtend@>=4.0.0 <5.0.0",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                         }
                       }
                     },
                     "pinkie-promise": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                      "from": "pinkie-promise@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                          "from": "pinkie@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                         }
                       }
@@ -1848,54 +1848,54 @@
             },
             "sass-graph": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
+              "from": "sass-graph@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "from": "lodash@>=3.8.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "yargs": {
                   "version": "3.29.0",
-                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
+                  "from": "yargs@>=3.8.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "from": "camelcase@>=1.2.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "cliui": {
                       "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/cliui/-/cliui-3.0.3.tgz",
+                      "from": "cliui@>=3.0.3 <4.0.0",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.0.3.tgz",
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+                          "from": "string-width@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                              "from": "code-point-at@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                              "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -1904,41 +1904,41 @@
                         },
                         "strip-ansi": {
                           "version": "3.0.0",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "wrap-ansi": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz",
+                          "from": "wrap-ansi@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
                     },
                     "os-locale": {
                       "version": "1.4.0",
-                      "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                      "from": "os-locale@>=1.4.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                       "dependencies": {
                         "lcid": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                          "from": "lcid@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                           "dependencies": {
                             "invert-kv": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                              "from": "invert-kv@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
                             }
                           }
@@ -1947,12 +1947,12 @@
                     },
                     "window-size": {
                       "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz",
+                      "from": "window-size@>=0.1.2 <0.2.0",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
                     },
                     "y18n": {
                       "version": "3.2.0",
-                      "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz",
+                      "from": "y18n@>=3.2.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
                     }
                   }
@@ -1963,66 +1963,66 @@
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+          "from": "object-assign@>=4.0.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         },
         "through2": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "from": "through2@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "from": "xtend@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
+          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "from": "source-map@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             }
           }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,5555 +2,172 @@
   "name": "optimizely-oui",
   "version": "6.0.0",
   "dependencies": {
-    "browser-sync": {
-      "version": "2.9.11",
-      "from": "browser-sync@>=2.9.8 <3.0.0",
+    "gulp-sass": {
+      "version": "2.1.0",
+      "from": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-2.1.0.tgz",
       "dependencies": {
-        "anymatch": {
-          "version": "1.3.0",
-          "from": "anymatch@>=1.3.0 <2.0.0",
-          "dependencies": {
-            "arrify": {
-              "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0"
-            },
-            "micromatch": {
-              "version": "2.2.0",
-              "from": "micromatch@>=2.1.5 <3.0.0",
-              "dependencies": {
-                "arr-diff": {
-                  "version": "1.1.0",
-                  "from": "arr-diff@>=1.0.1 <2.0.0",
-                  "dependencies": {
-                    "arr-flatten": {
-                      "version": "1.0.1",
-                      "from": "arr-flatten@>=1.0.1 <2.0.0"
-                    },
-                    "array-slice": {
-                      "version": "0.2.3",
-                      "from": "array-slice@>=0.2.3 <0.3.0"
-                    }
-                  }
-                },
-                "array-unique": {
-                  "version": "0.2.1",
-                  "from": "array-unique@>=0.2.1 <0.3.0"
-                },
-                "braces": {
-                  "version": "1.8.2",
-                  "from": "braces@>=1.8.0 <2.0.0",
-                  "dependencies": {
-                    "expand-range": {
-                      "version": "1.8.1",
-                      "from": "expand-range@>=1.8.1 <2.0.0",
-                      "dependencies": {
-                        "fill-range": {
-                          "version": "2.2.2",
-                          "from": "fill-range@>=2.1.0 <3.0.0",
-                          "dependencies": {
-                            "is-number": {
-                              "version": "1.1.2",
-                              "from": "is-number@>=1.1.2 <2.0.0"
-                            },
-                            "isobject": {
-                              "version": "1.0.2",
-                              "from": "isobject@>=1.0.0 <2.0.0"
-                            },
-                            "randomatic": {
-                              "version": "1.1.0",
-                              "from": "randomatic@>=1.1.0 <2.0.0"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "lazy-cache": {
-                      "version": "0.2.4",
-                      "from": "lazy-cache@>=0.2.3 <0.3.0"
-                    },
-                    "preserve": {
-                      "version": "0.2.0",
-                      "from": "preserve@>=0.2.0 <0.3.0"
-                    },
-                    "repeat-element": {
-                      "version": "1.1.2",
-                      "from": "repeat-element@>=1.1.2 <2.0.0"
-                    }
-                  }
-                },
-                "expand-brackets": {
-                  "version": "0.1.4",
-                  "from": "expand-brackets@>=0.1.1 <0.2.0"
-                },
-                "extglob": {
-                  "version": "0.3.1",
-                  "from": "extglob@>=0.3.0 <0.4.0",
-                  "dependencies": {
-                    "ansi-green": {
-                      "version": "0.1.1",
-                      "from": "ansi-green@>=0.1.1 <0.2.0",
-                      "dependencies": {
-                        "ansi-wrap": {
-                          "version": "0.1.0",
-                          "from": "ansi-wrap@0.1.0"
-                        }
-                      }
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0"
-                    },
-                    "success-symbol": {
-                      "version": "0.1.0",
-                      "from": "success-symbol@>=0.1.0 <0.2.0"
-                    }
-                  }
-                },
-                "filename-regex": {
-                  "version": "2.0.0",
-                  "from": "filename-regex@>=2.0.0 <3.0.0"
-                },
-                "is-glob": {
-                  "version": "1.1.3",
-                  "from": "is-glob@>=1.1.3 <2.0.0"
-                },
-                "kind-of": {
-                  "version": "1.1.0",
-                  "from": "kind-of@>=1.1.0 <2.0.0"
-                },
-                "object.omit": {
-                  "version": "1.1.0",
-                  "from": "object.omit@>=1.1.0 <2.0.0",
-                  "dependencies": {
-                    "for-own": {
-                      "version": "0.1.3",
-                      "from": "for-own@>=0.1.3 <0.2.0",
-                      "dependencies": {
-                        "for-in": {
-                          "version": "0.1.4",
-                          "from": "for-in@>=0.1.4 <0.2.0"
-                        }
-                      }
-                    },
-                    "isobject": {
-                      "version": "1.0.2",
-                      "from": "isobject@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "parse-glob": {
-                  "version": "3.0.4",
-                  "from": "parse-glob@>=3.0.1 <4.0.0",
-                  "dependencies": {
-                    "glob-base": {
-                      "version": "0.3.0",
-                      "from": "glob-base@>=0.3.0 <0.4.0",
-                      "dependencies": {
-                        "glob-parent": {
-                          "version": "2.0.0",
-                          "from": "glob-parent@>=2.0.0 <3.0.0"
-                        }
-                      }
-                    },
-                    "is-dotfile": {
-                      "version": "1.0.2",
-                      "from": "is-dotfile@>=1.0.0 <2.0.0"
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0"
-                    },
-                    "is-glob": {
-                      "version": "2.0.1",
-                      "from": "is-glob@>=2.0.0 <3.0.0"
-                    }
-                  }
-                },
-                "regex-cache": {
-                  "version": "0.4.2",
-                  "from": "regex-cache@>=0.4.2 <0.5.0",
-                  "dependencies": {
-                    "is-equal-shallow": {
-                      "version": "0.1.3",
-                      "from": "is-equal-shallow@>=0.1.1 <0.2.0"
-                    },
-                    "is-primitive": {
-                      "version": "2.0.0",
-                      "from": "is-primitive@>=2.0.0 <3.0.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "async-each-series": {
-          "version": "0.1.1",
-          "from": "async-each-series@>=0.1.1 <0.2.0"
-        },
-        "browser-sync-client": {
-          "version": "2.3.4",
-          "from": "browser-sync-client@>=2.3.3 <3.0.0",
-          "dependencies": {
-            "etag": {
-              "version": "1.7.0",
-              "from": "etag@>=1.7.0 <2.0.0"
-            },
-            "fresh": {
-              "version": "0.3.0",
-              "from": "fresh@>=0.3.0 <0.4.0"
-            }
-          }
-        },
-        "browser-sync-ui": {
-          "version": "0.5.16",
-          "from": "browser-sync-ui@>=0.5.16 <0.6.0",
-          "dependencies": {
-            "connect-history-api-fallback": {
-              "version": "0.0.5",
-              "from": "connect-history-api-fallback@0.0.5"
-            },
-            "stream-throttle": {
-              "version": "0.1.3",
-              "from": "stream-throttle@>=0.1.3 <0.2.0",
-              "dependencies": {
-                "commander": {
-                  "version": "2.9.0",
-                  "from": "commander@>=2.2.0 <3.0.0",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0"
-                    }
-                  }
-                },
-                "limiter": {
-                  "version": "1.1.0",
-                  "from": "limiter@>=1.0.5 <2.0.0"
-                }
-              }
-            },
-            "weinre": {
-              "version": "2.0.0-pre-I0Z7U9OV",
-              "from": "weinre@>=2.0.0-pre-I0Z7U9OV <3.0.0",
-              "dependencies": {
-                "express": {
-                  "version": "2.5.11",
-                  "from": "express@>=2.5.0 <2.6.0",
-                  "dependencies": {
-                    "connect": {
-                      "version": "1.9.2",
-                      "from": "connect@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "formidable": {
-                          "version": "1.0.17",
-                          "from": "formidable@>=1.0.0 <1.1.0"
-                        }
-                      }
-                    },
-                    "mime": {
-                      "version": "1.2.4",
-                      "from": "mime@1.2.4"
-                    },
-                    "qs": {
-                      "version": "0.4.2",
-                      "from": "qs@>=0.4.0 <0.5.0"
-                    },
-                    "mkdirp": {
-                      "version": "0.3.0",
-                      "from": "mkdirp@0.3.0"
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "3.0.4",
-                  "from": "nopt@>=3.0.0 <3.1.0",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "underscore": {
-                  "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0"
-                }
-              }
-            }
-          }
-        },
-        "chokidar": {
-          "version": "1.2.0",
-          "from": "chokidar@>=1.0.5 <2.0.0",
-          "dependencies": {
-            "arrify": {
-              "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0"
-            },
-            "async-each": {
-              "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0"
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "from": "glob-parent@>=2.0.0 <3.0.0"
-            },
-            "is-binary-path": {
-              "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
-              "dependencies": {
-                "binary-extensions": {
-                  "version": "1.3.1",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0"
-                }
-              }
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "from": "is-glob@>=2.0.0 <3.0.0",
-              "dependencies": {
-                "is-extglob": {
-                  "version": "1.0.0",
-                  "from": "is-extglob@>=1.0.0 <2.0.0"
-                }
-              }
-            },
-            "lodash.flatten": {
-              "version": "3.0.2",
-              "from": "lodash.flatten@>=3.0.2 <4.0.0",
-              "dependencies": {
-                "lodash._baseflatten": {
-                  "version": "3.1.4",
-                  "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
-                  "dependencies": {
-                    "lodash.isarguments": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0"
-                    }
-                  }
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9",
-                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0"
-            },
-            "readdirp": {
-              "version": "2.0.0",
-              "from": "readdirp@>=2.0.0 <3.0.0",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "minimatch@>=2.0.10 <3.0.0",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.1",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.1",
-                          "from": "balanced-match@>=0.2.0 <0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.0.3",
-                  "from": "readable-stream@>=2.0.2 <3.0.0",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.3",
-                      "from": "process-nextick-args@>=1.0.0 <1.1.0"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0"
-                    }
-                  }
-                }
-              }
-            },
-            "fsevents": {
-              "version": "1.0.2",
-              "from": "fsevents@>=1.0.0 <2.0.0",
-              "dependencies": {
-                "nan": {
-                  "version": "2.1.0",
-                  "from": "nan@>=2.0.2 <3.0.0"
-                },
-                "node-pre-gyp": {
-                  "version": "0.6.12",
-                  "from": "node-pre-gyp@0.6.12",
-                  "dependencies": {
-                    "nopt": {
-                      "version": "3.0.4",
-                      "from": "nopt@~3.0.1",
-                      "dependencies": {
-                        "abbrev": {
-                          "version": "1.0.7",
-                          "from": "abbrev@1"
-                        }
-                      }
-                    },
-                    "npmlog": {
-                      "version": "1.2.1",
-                      "from": "npmlog@~1.2.0",
-                      "dependencies": {
-                        "ansi": {
-                          "version": "0.3.0",
-                          "from": "ansi@~0.3.0"
-                        },
-                        "are-we-there-yet": {
-                          "version": "1.0.4",
-                          "from": "are-we-there-yet@~1.0.0",
-                          "dependencies": {
-                            "delegates": {
-                              "version": "0.1.0",
-                              "from": "delegates@^0.1.0"
-                            },
-                            "readable-stream": {
-                              "version": "1.1.13",
-                              "from": "readable-stream@^1.1.13",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.1",
-                                  "from": "core-util-is@~1.0.0"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "isarray@0.0.1"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "string_decoder@~0.10.x"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@2"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "gauge": {
-                          "version": "1.2.2",
-                          "from": "gauge@~1.2.0",
-                          "dependencies": {
-                            "has-unicode": {
-                              "version": "1.0.0",
-                              "from": "has-unicode@^1.0.0"
-                            },
-                            "lodash.pad": {
-                              "version": "3.1.1",
-                              "from": "lodash.pad@^3.0.0",
-                              "dependencies": {
-                                "lodash._basetostring": {
-                                  "version": "3.0.1",
-                                  "from": "lodash._basetostring@^3.0.0"
-                                },
-                                "lodash._createpadding": {
-                                  "version": "3.6.1",
-                                  "from": "lodash._createpadding@^3.0.0",
-                                  "dependencies": {
-                                    "lodash.repeat": {
-                                      "version": "3.0.1",
-                                      "from": "lodash.repeat@^3.0.0"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "lodash.padleft": {
-                              "version": "3.1.1",
-                              "from": "lodash.padleft@^3.0.0",
-                              "dependencies": {
-                                "lodash._basetostring": {
-                                  "version": "3.0.1",
-                                  "from": "lodash._basetostring@^3.0.0"
-                                },
-                                "lodash._createpadding": {
-                                  "version": "3.6.1",
-                                  "from": "lodash._createpadding@^3.0.0",
-                                  "dependencies": {
-                                    "lodash.repeat": {
-                                      "version": "3.0.1",
-                                      "from": "lodash.repeat@^3.0.0"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "lodash.padright": {
-                              "version": "3.1.1",
-                              "from": "lodash.padright@^3.0.0",
-                              "dependencies": {
-                                "lodash._basetostring": {
-                                  "version": "3.0.1",
-                                  "from": "lodash._basetostring@^3.0.0"
-                                },
-                                "lodash._createpadding": {
-                                  "version": "3.6.1",
-                                  "from": "lodash._createpadding@^3.0.0",
-                                  "dependencies": {
-                                    "lodash.repeat": {
-                                      "version": "3.0.1",
-                                      "from": "lodash.repeat@^3.0.0"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "request": {
-                      "version": "2.64.0",
-                      "from": "request@2.x",
-                      "dependencies": {
-                        "bl": {
-                          "version": "1.0.0",
-                          "from": "bl@~1.0.0",
-                          "dependencies": {
-                            "readable-stream": {
-                              "version": "2.0.2",
-                              "from": "readable-stream@~2.0.0",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.1",
-                                  "from": "core-util-is@~1.0.0"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@~2.0.1"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "isarray@0.0.1"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.3",
-                                  "from": "process-nextick-args@~1.0.0"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "string_decoder@~0.10.x"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.1",
-                                  "from": "util-deprecate@~1.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "caseless": {
-                          "version": "0.11.0",
-                          "from": "caseless@~0.11.0"
-                        },
-                        "extend": {
-                          "version": "3.0.0",
-                          "from": "extend@~3.0.0"
-                        },
-                        "forever-agent": {
-                          "version": "0.6.1",
-                          "from": "forever-agent@~0.6.0"
-                        },
-                        "form-data": {
-                          "version": "1.0.0-rc3",
-                          "from": "form-data@~1.0.0-rc1",
-                          "dependencies": {
-                            "async": {
-                              "version": "1.4.2",
-                              "from": "async@^1.4.0"
-                            }
-                          }
-                        },
-                        "json-stringify-safe": {
-                          "version": "5.0.1",
-                          "from": "json-stringify-safe@~5.0.0"
-                        },
-                        "mime-types": {
-                          "version": "2.1.7",
-                          "from": "mime-types@~2.1.2",
-                          "dependencies": {
-                            "mime-db": {
-                              "version": "1.19.0",
-                              "from": "mime-db@~1.19.0"
-                            }
-                          }
-                        },
-                        "node-uuid": {
-                          "version": "1.4.3",
-                          "from": "node-uuid@~1.4.0"
-                        },
-                        "qs": {
-                          "version": "5.1.0",
-                          "from": "qs@~5.1.0"
-                        },
-                        "tunnel-agent": {
-                          "version": "0.4.1",
-                          "from": "tunnel-agent@~0.4.0"
-                        },
-                        "tough-cookie": {
-                          "version": "2.1.0",
-                          "from": "tough-cookie@>=0.12.0"
-                        },
-                        "http-signature": {
-                          "version": "0.11.0",
-                          "from": "http-signature@~0.11.0",
-                          "dependencies": {
-                            "assert-plus": {
-                              "version": "0.1.5",
-                              "from": "assert-plus@^0.1.5"
-                            },
-                            "asn1": {
-                              "version": "0.1.11",
-                              "from": "asn1@0.1.11"
-                            },
-                            "ctype": {
-                              "version": "0.5.3",
-                              "from": "ctype@0.5.3"
-                            }
-                          }
-                        },
-                        "oauth-sign": {
-                          "version": "0.8.0",
-                          "from": "oauth-sign@~0.8.0"
-                        },
-                        "hawk": {
-                          "version": "3.1.0",
-                          "from": "hawk@~3.1.0",
-                          "dependencies": {
-                            "hoek": {
-                              "version": "2.16.3",
-                              "from": "hoek@2.x.x"
-                            },
-                            "boom": {
-                              "version": "2.9.0",
-                              "from": "boom@^2.8.x"
-                            },
-                            "cryptiles": {
-                              "version": "2.0.5",
-                              "from": "cryptiles@2.x.x"
-                            },
-                            "sntp": {
-                              "version": "1.0.9",
-                              "from": "sntp@1.x.x"
-                            }
-                          }
-                        },
-                        "aws-sign2": {
-                          "version": "0.5.0",
-                          "from": "aws-sign2@~0.5.0"
-                        },
-                        "stringstream": {
-                          "version": "0.0.4",
-                          "from": "stringstream@~0.0.4"
-                        },
-                        "combined-stream": {
-                          "version": "1.0.5",
-                          "from": "combined-stream@~1.0.1",
-                          "dependencies": {
-                            "delayed-stream": {
-                              "version": "1.0.0",
-                              "from": "delayed-stream@~1.0.0"
-                            }
-                          }
-                        },
-                        "isstream": {
-                          "version": "0.1.2",
-                          "from": "isstream@~0.1.1"
-                        },
-                        "har-validator": {
-                          "version": "1.8.0",
-                          "from": "har-validator@^1.6.1",
-                          "dependencies": {
-                            "bluebird": {
-                              "version": "2.10.2",
-                              "from": "bluebird@^2.9.30"
-                            },
-                            "chalk": {
-                              "version": "1.1.1",
-                              "from": "chalk@^1.0.0",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.1.0",
-                                  "from": "ansi-styles@^2.1.0"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.3",
-                                  "from": "escape-string-regexp@^1.0.2"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "has-ansi@^2.0.0",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "ansi-regex@^2.0.0"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.0",
-                                  "from": "strip-ansi@^3.0.0",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "ansi-regex@^2.0.0"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "supports-color@^2.0.0"
-                                }
-                              }
-                            },
-                            "commander": {
-                              "version": "2.8.1",
-                              "from": "commander@^2.8.1",
-                              "dependencies": {
-                                "graceful-readlink": {
-                                  "version": "1.0.1",
-                                  "from": "graceful-readlink@>= 1.0.0"
-                                }
-                              }
-                            },
-                            "is-my-json-valid": {
-                              "version": "2.12.2",
-                              "from": "is-my-json-valid@^2.12.0",
-                              "dependencies": {
-                                "generate-function": {
-                                  "version": "2.0.0",
-                                  "from": "generate-function@^2.0.0"
-                                },
-                                "generate-object-property": {
-                                  "version": "1.2.0",
-                                  "from": "generate-object-property@^1.1.0",
-                                  "dependencies": {
-                                    "is-property": {
-                                      "version": "1.0.2",
-                                      "from": "is-property@^1.0.0"
-                                    }
-                                  }
-                                },
-                                "jsonpointer": {
-                                  "version": "2.0.0",
-                                  "from": "jsonpointer@2.0.0"
-                                },
-                                "xtend": {
-                                  "version": "4.0.0",
-                                  "from": "xtend@^4.0.0"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "semver": {
-                      "version": "5.0.3",
-                      "from": "semver@~5.0.1"
-                    },
-                    "tar": {
-                      "version": "2.2.1",
-                      "from": "tar@~2.2.0",
-                      "dependencies": {
-                        "block-stream": {
-                          "version": "0.0.8",
-                          "from": "block-stream@*"
-                        },
-                        "fstream": {
-                          "version": "1.0.8",
-                          "from": "fstream@^1.0.2",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.2",
-                              "from": "graceful-fs@^4.1.2"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@2"
-                        }
-                      }
-                    },
-                    "tar-pack": {
-                      "version": "2.0.0",
-                      "from": "tar-pack@~2.0.0",
-                      "dependencies": {
-                        "uid-number": {
-                          "version": "0.0.3",
-                          "from": "uid-number@0.0.3"
-                        },
-                        "once": {
-                          "version": "1.1.1",
-                          "from": "once@~1.1.1"
-                        },
-                        "debug": {
-                          "version": "0.7.4",
-                          "from": "debug@~0.7.2"
-                        },
-                        "rimraf": {
-                          "version": "2.2.8",
-                          "from": "rimraf@~2.2.0"
-                        },
-                        "fstream": {
-                          "version": "0.1.31",
-                          "from": "fstream@~0.1.22",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "3.0.8",
-                              "from": "graceful-fs@~3.0.2"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@~2.0.0"
-                            }
-                          }
-                        },
-                        "tar": {
-                          "version": "0.1.20",
-                          "from": "tar@~0.1.17",
-                          "dependencies": {
-                            "block-stream": {
-                              "version": "0.0.8",
-                              "from": "block-stream@*"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@2"
-                            }
-                          }
-                        },
-                        "fstream-ignore": {
-                          "version": "0.0.7",
-                          "from": "fstream-ignore@0.0.7",
-                          "dependencies": {
-                            "minimatch": {
-                              "version": "0.2.14",
-                              "from": "minimatch@~0.2.0",
-                              "dependencies": {
-                                "lru-cache": {
-                                  "version": "2.7.0",
-                                  "from": "lru-cache@2"
-                                },
-                                "sigmund": {
-                                  "version": "1.0.1",
-                                  "from": "sigmund@~1.0.0"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@~2.0.1"
-                            }
-                          }
-                        },
-                        "readable-stream": {
-                          "version": "1.0.33",
-                          "from": "readable-stream@~1.0.2",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@~0.10.x"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@~2.0.1"
-                            }
-                          }
-                        },
-                        "graceful-fs": {
-                          "version": "1.2.3",
-                          "from": "graceful-fs@1.2"
-                        }
-                      }
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@~0.5.0",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8"
-                        }
-                      }
-                    },
-                    "rc": {
-                      "version": "1.1.2",
-                      "from": "rc@~1.1.0",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@^1.1.2"
-                        },
-                        "deep-extend": {
-                          "version": "0.2.11",
-                          "from": "deep-extend@~0.2.5"
-                        },
-                        "strip-json-comments": {
-                          "version": "0.1.3",
-                          "from": "strip-json-comments@0.1.x"
-                        },
-                        "ini": {
-                          "version": "1.3.4",
-                          "from": "ini@~1.3.0"
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.4.3",
-                      "from": "rimraf@~2.4.0",
-                      "dependencies": {
-                        "glob": {
-                          "version": "5.0.15",
-                          "from": "glob@^5.0.14",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "from": "inflight@^1.0.4",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@1"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@~2.0.1"
-                            },
-                            "minimatch": {
-                              "version": "3.0.0",
-                              "from": "minimatch@2 || 3",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.1",
-                                  "from": "brace-expansion@^1.0.0",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.2.0",
-                                      "from": "balanced-match@^0.2.0"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1",
-                                      "from": "concat-map@0.0.1"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.2",
-                              "from": "once@^1.3.0",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@1"
-                                }
-                              }
-                            },
-                            "path-is-absolute": {
-                              "version": "1.0.0",
-                              "from": "path-is-absolute@^1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "connect": {
-          "version": "3.4.0",
-          "from": "connect@>=3.4.0 <4.0.0",
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1"
-                }
-              }
-            },
-            "finalhandler": {
-              "version": "0.4.0",
-              "from": "finalhandler@0.4.0",
-              "dependencies": {
-                "escape-html": {
-                  "version": "1.0.2",
-                  "from": "escape-html@1.0.2"
-                },
-                "on-finished": {
-                  "version": "2.3.0",
-                  "from": "on-finished@>=2.3.0 <2.4.0",
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.1.1",
-                      "from": "ee-first@1.1.1"
-                    }
-                  }
-                },
-                "unpipe": {
-                  "version": "1.0.0",
-                  "from": "unpipe@>=1.0.0 <1.1.0"
-                }
-              }
-            },
-            "parseurl": {
-              "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0"
-            },
-            "utils-merge": {
-              "version": "1.0.0",
-              "from": "utils-merge@1.0.0"
-            }
-          }
-        },
-        "dev-ip": {
-          "version": "1.0.1",
-          "from": "dev-ip@>=1.0.1 <2.0.0"
-        },
-        "easy-extender": {
-          "version": "2.3.1",
-          "from": "easy-extender@>=2.3.1 <3.0.0",
-          "dependencies": {
-            "lodash": {
-              "version": "2.4.2",
-              "from": "lodash@>=2.4.1 <3.0.0"
-            }
-          }
-        },
-        "eazy-logger": {
-          "version": "2.1.2",
-          "from": "eazy-logger@>=2.1.2 <3.0.0",
-          "dependencies": {
-            "opt-merger": {
-              "version": "1.1.0",
-              "from": "opt-merger@>=1.1.0 <2.0.0",
-              "dependencies": {
-                "lodash": {
-                  "version": "2.4.2",
-                  "from": "lodash@>=2.4.1 <3.0.0"
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@>=1.1.0 <2.0.0"
-                }
-              }
-            },
-            "tfunk": {
-              "version": "3.0.1",
-              "from": "tfunk@>=3.0.1 <4.0.0",
-              "dependencies": {
-                "chalk": {
-                  "version": "0.5.1",
-                  "from": "chalk@>=0.5.1 <0.6.0",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "1.1.0",
-                      "from": "ansi-styles@>=1.1.0 <2.0.0"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.3",
-                      "from": "escape-string-regexp@>=1.0.0 <2.0.0"
-                    },
-                    "has-ansi": {
-                      "version": "0.1.0",
-                      "from": "has-ansi@>=0.1.0 <0.2.0",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "0.3.0",
-                      "from": "strip-ansi@>=0.3.0 <0.4.0",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "0.2.0",
-                      "from": "supports-color@>=0.2.0 <0.3.0"
-                    }
-                  }
-                },
-                "object-path": {
-                  "version": "0.9.2",
-                  "from": "object-path@>=0.9.0 <0.10.0"
-                }
-              }
-            }
-          }
-        },
-        "emitter-steward": {
-          "version": "1.0.0",
-          "from": "emitter-steward@>=1.0.0 <2.0.0"
-        },
-        "foxy": {
-          "version": "11.1.3",
-          "from": "foxy@>=11.1.2 <12.0.0",
-          "dependencies": {
-            "cookie": {
-              "version": "0.1.5",
-              "from": "cookie@>=0.1.3 <0.2.0"
-            },
-            "http-proxy": {
-              "version": "1.12.0",
-              "from": "http-proxy@>=1.9.0 <2.0.0",
-              "dependencies": {
-                "eventemitter3": {
-                  "version": "1.1.1",
-                  "from": "eventemitter3@>=1.0.0 <2.0.0"
-                },
-                "requires-port": {
-                  "version": "0.0.1",
-                  "from": "requires-port@>=0.0.0 <1.0.0"
-                }
-              }
-            },
-            "lodash.merge": {
-              "version": "3.3.2",
-              "from": "lodash.merge@>=3.3.1 <4.0.0",
-              "dependencies": {
-                "lodash._arraycopy": {
-                  "version": "3.0.0",
-                  "from": "lodash._arraycopy@>=3.0.0 <4.0.0"
-                },
-                "lodash._arrayeach": {
-                  "version": "3.0.0",
-                  "from": "lodash._arrayeach@>=3.0.0 <4.0.0"
-                },
-                "lodash._createassigner": {
-                  "version": "3.1.1",
-                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
-                  "dependencies": {
-                    "lodash._bindcallback": {
-                      "version": "3.0.1",
-                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0"
-                    },
-                    "lodash._isiterateecall": {
-                      "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0"
-                    },
-                    "lodash.restparam": {
-                      "version": "3.6.1",
-                      "from": "lodash.restparam@>=3.0.0 <4.0.0"
-                    }
-                  }
-                },
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0"
-                },
-                "lodash.isplainobject": {
-                  "version": "3.2.0",
-                  "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
-                  "dependencies": {
-                    "lodash._basefor": {
-                      "version": "3.0.2",
-                      "from": "lodash._basefor@>=3.0.0 <4.0.0"
-                    }
-                  }
-                },
-                "lodash.istypedarray": {
-                  "version": "3.0.2",
-                  "from": "lodash.istypedarray@>=3.0.0 <4.0.0"
-                },
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "from": "lodash.keys@>=3.0.0 <4.0.0"
-                },
-                "lodash.keysin": {
-                  "version": "3.0.8",
-                  "from": "lodash.keysin@>=3.0.0 <4.0.0"
-                },
-                "lodash.toplainobject": {
-                  "version": "3.0.0",
-                  "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
-                  "dependencies": {
-                    "lodash._basecopy": {
-                      "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "resp-modifier": {
-              "version": "4.0.4",
-              "from": "resp-modifier@>=4.0.2 <5.0.0",
-              "dependencies": {
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.1",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.1",
-                          "from": "balanced-match@>=0.2.0 <0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "immutable": {
-          "version": "3.7.5",
-          "from": "immutable@>=3.7.4 <4.0.0"
-        },
-        "localtunnel": {
-          "version": "1.7.0",
-          "from": "localtunnel@>=1.7.0 <2.0.0",
-          "dependencies": {
-            "request": {
-              "version": "2.11.4",
-              "from": "request@2.11.4",
-              "dependencies": {
-                "form-data": {
-                  "version": "0.0.3",
-                  "from": "form-data",
-                  "dependencies": {
-                    "combined-stream": {
-                      "version": "0.0.3",
-                      "from": "combined-stream@0.0.3",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5"
-                        }
-                      }
-                    },
-                    "async": {
-                      "version": "0.1.9",
-                      "from": "async@0.1.9"
-                    }
-                  }
-                },
-                "mime": {
-                  "version": "1.2.7",
-                  "from": "mime"
-                }
-              }
-            },
-            "yargs": {
-              "version": "3.15.0",
-              "from": "yargs@3.15.0",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0"
-                },
-                "cliui": {
-                  "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
-                  "dependencies": {
-                    "center-align": {
-                      "version": "0.1.2",
-                      "from": "center-align@>=0.1.1 <0.2.0",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.3",
-                          "from": "align-text@>=0.1.0 <0.2.0",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0"
-                                }
-                              }
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0"
-                            }
-                          }
-                        },
-                        "lazy-cache": {
-                          "version": "0.2.4",
-                          "from": "lazy-cache@>=0.2.4 <0.3.0"
-                        }
-                      }
-                    },
-                    "right-align": {
-                      "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.3",
-                          "from": "align-text@>=0.1.0 <0.2.0",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0"
-                                }
-                              }
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "wordwrap@0.0.2"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.1.1",
-                  "from": "decamelize@>=1.0.0 <2.0.0"
-                },
-                "window-size": {
-                  "version": "0.1.2",
-                  "from": "window-size@>=0.1.1 <0.2.0"
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4",
-              "from": "debug@0.7.4"
-            },
-            "openurl": {
-              "version": "1.1.0",
-              "from": "openurl@1.1.0"
-            }
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.9.3 <4.0.0"
-        },
-        "longest": {
-          "version": "1.0.1",
-          "from": "longest@>=1.0.1 <2.0.0"
-        },
-        "meow": {
-          "version": "3.3.0",
-          "from": "meow@3.3.0",
-          "dependencies": {
-            "camelcase-keys": {
-              "version": "1.0.0",
-              "from": "camelcase-keys@>=1.0.0 <2.0.0",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1",
-                  "from": "camelcase@>=1.0.1 <2.0.0"
-                },
-                "map-obj": {
-                  "version": "1.0.1",
-                  "from": "map-obj@>=1.0.0 <2.0.0"
-                }
-              }
-            },
-            "indent-string": {
-              "version": "1.2.2",
-              "from": "indent-string@>=1.1.0 <2.0.0",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0"
-                },
-                "repeating": {
-                  "version": "1.1.3",
-                  "from": "repeating@>=1.1.0 <2.0.0",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.1.0 <2.0.0"
-            },
-            "object-assign": {
-              "version": "3.0.0",
-              "from": "object-assign@>=3.0.0 <4.0.0"
-            }
-          }
-        },
-        "opn": {
-          "version": "3.0.2",
-          "from": "opn@>=3.0.2 <4.0.0",
-          "dependencies": {
-            "object-assign": {
-              "version": "3.0.0",
-              "from": "object-assign@>=3.0.0 <4.0.0"
-            }
-          }
-        },
-        "pad-left": {
-          "version": "2.0.0",
-          "from": "pad-left@>=2.0.0 <3.0.0",
-          "dependencies": {
-            "repeat-string": {
-              "version": "1.5.2",
-              "from": "repeat-string@>=1.5.2 <2.0.0"
-            }
-          }
-        },
-        "portscanner": {
-          "version": "1.0.0",
-          "from": "portscanner@>=1.0.0 <2.0.0",
-          "dependencies": {
-            "async": {
-              "version": "0.1.15",
-              "from": "async@0.1.15"
-            }
-          }
-        },
-        "query-string": {
-          "version": "2.4.2",
-          "from": "query-string@>=2.4.0 <3.0.0",
-          "dependencies": {
-            "strict-uri-encode": {
-              "version": "1.0.2",
-              "from": "strict-uri-encode@>=1.0.0 <2.0.0"
-            }
-          }
-        },
-        "resp-modifier": {
-          "version": "5.0.2",
-          "from": "resp-modifier@>=5.0.0 <6.0.0",
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@>=2.2.0 <3.0.0",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.1",
-                      "from": "balanced-match@>=0.2.0 <0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "serve-index": {
-          "version": "1.7.2",
-          "from": "serve-index@>=1.7.0 <2.0.0",
-          "dependencies": {
-            "accepts": {
-              "version": "1.2.13",
-              "from": "accepts@>=1.2.12 <1.3.0",
-              "dependencies": {
-                "negotiator": {
-                  "version": "0.5.3",
-                  "from": "negotiator@0.5.3"
-                }
-              }
-            },
-            "batch": {
-              "version": "0.5.2",
-              "from": "batch@0.5.2"
-            },
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1"
-                }
-              }
-            },
-            "escape-html": {
-              "version": "1.0.2",
-              "from": "escape-html@1.0.2"
-            },
-            "http-errors": {
-              "version": "1.3.1",
-              "from": "http-errors@>=1.3.1 <1.4.0",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                },
-                "statuses": {
-                  "version": "1.2.1",
-                  "from": "statuses@>=1.0.0 <2.0.0"
-                }
-              }
-            },
-            "mime-types": {
-              "version": "2.1.7",
-              "from": "mime-types@>=2.1.4 <2.2.0",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.19.0",
-                  "from": "mime-db@>=1.19.0 <1.20.0"
-                }
-              }
-            },
-            "parseurl": {
-              "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0"
-            }
-          }
-        },
-        "serve-static": {
-          "version": "1.10.0",
-          "from": "serve-static@>=1.10.0 <2.0.0",
-          "dependencies": {
-            "escape-html": {
-              "version": "1.0.2",
-              "from": "escape-html@1.0.2"
-            },
-            "parseurl": {
-              "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0"
-            },
-            "send": {
-              "version": "0.13.0",
-              "from": "send@0.13.0",
-              "dependencies": {
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <2.3.0"
-                },
-                "depd": {
-                  "version": "1.0.1",
-                  "from": "depd@>=1.0.1 <1.1.0"
-                },
-                "destroy": {
-                  "version": "1.0.3",
-                  "from": "destroy@1.0.3"
-                },
-                "etag": {
-                  "version": "1.7.0",
-                  "from": "etag@>=1.7.0 <1.8.0"
-                },
-                "fresh": {
-                  "version": "0.3.0",
-                  "from": "fresh@0.3.0"
-                },
-                "http-errors": {
-                  "version": "1.3.1",
-                  "from": "http-errors@>=1.3.1 <1.4.0",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0"
-                    }
-                  }
-                },
-                "mime": {
-                  "version": "1.3.4",
-                  "from": "mime@1.3.4"
-                },
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1"
-                },
-                "on-finished": {
-                  "version": "2.3.0",
-                  "from": "on-finished@>=2.3.0 <2.4.0",
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.1.1",
-                      "from": "ee-first@1.1.1"
-                    }
-                  }
-                },
-                "range-parser": {
-                  "version": "1.0.2",
-                  "from": "range-parser@>=1.0.2 <1.1.0"
-                },
-                "statuses": {
-                  "version": "1.2.1",
-                  "from": "statuses@>=1.2.1 <1.3.0"
-                }
-              }
-            }
-          }
-        },
-        "socket.io": {
-          "version": "1.3.7",
-          "from": "socket.io@>=1.3.7 <2.0.0",
-          "dependencies": {
-            "engine.io": {
-              "version": "1.5.4",
-              "from": "engine.io@1.5.4",
-              "dependencies": {
-                "base64id": {
-                  "version": "0.1.0",
-                  "from": "base64id@0.1.0"
-                },
-                "debug": {
-                  "version": "1.0.3",
-                  "from": "debug@1.0.3",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2"
-                    }
-                  }
-                },
-                "engine.io-parser": {
-                  "version": "1.2.2",
-                  "from": "engine.io-parser@1.2.2",
-                  "dependencies": {
-                    "after": {
-                      "version": "0.8.1",
-                      "from": "after@0.8.1"
-                    },
-                    "arraybuffer.slice": {
-                      "version": "0.0.6",
-                      "from": "arraybuffer.slice@0.0.6"
-                    },
-                    "base64-arraybuffer": {
-                      "version": "0.1.2",
-                      "from": "base64-arraybuffer@0.1.2"
-                    },
-                    "blob": {
-                      "version": "0.0.4",
-                      "from": "blob@0.0.4"
-                    },
-                    "has-binary": {
-                      "version": "0.1.6",
-                      "from": "has-binary@0.1.6",
-                      "dependencies": {
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1"
-                        }
-                      }
-                    },
-                    "utf8": {
-                      "version": "2.1.0",
-                      "from": "utf8@2.1.0"
-                    }
-                  }
-                },
-                "ws": {
-                  "version": "0.8.0",
-                  "from": "ws@0.8.0",
-                  "dependencies": {
-                    "options": {
-                      "version": "0.0.6",
-                      "from": "options@>=0.0.5"
-                    },
-                    "ultron": {
-                      "version": "1.0.2",
-                      "from": "ultron@>=1.0.0 <1.1.0"
-                    },
-                    "bufferutil": {
-                      "version": "1.2.1",
-                      "from": "bufferutil@>=1.2.0 <1.3.0",
-                      "dependencies": {
-                        "bindings": {
-                          "version": "1.2.1",
-                          "from": "bindings@>=1.2.0 <1.3.0"
-                        },
-                        "nan": {
-                          "version": "2.1.0",
-                          "from": "nan@>=2.0.5 <3.0.0"
-                        }
-                      }
-                    },
-                    "utf-8-validate": {
-                      "version": "1.2.1",
-                      "from": "utf-8-validate@>=1.2.0 <1.3.0",
-                      "dependencies": {
-                        "bindings": {
-                          "version": "1.2.1",
-                          "from": "bindings@>=1.2.0 <1.3.0"
-                        },
-                        "nan": {
-                          "version": "2.1.0",
-                          "from": "nan@>=2.0.5 <3.0.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "socket.io-parser": {
-              "version": "2.2.4",
-              "from": "socket.io-parser@2.2.4",
-              "dependencies": {
-                "debug": {
-                  "version": "0.7.4",
-                  "from": "debug@0.7.4"
-                },
-                "json3": {
-                  "version": "3.2.6",
-                  "from": "json3@3.2.6"
-                },
-                "component-emitter": {
-                  "version": "1.1.2",
-                  "from": "component-emitter@1.1.2"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                },
-                "benchmark": {
-                  "version": "1.0.0",
-                  "from": "benchmark@1.0.0"
-                }
-              }
-            },
-            "socket.io-client": {
-              "version": "1.3.7",
-              "from": "socket.io-client@1.3.7",
-              "dependencies": {
-                "debug": {
-                  "version": "0.7.4",
-                  "from": "debug@0.7.4"
-                },
-                "engine.io-client": {
-                  "version": "1.5.4",
-                  "from": "engine.io-client@1.5.4",
-                  "dependencies": {
-                    "component-inherit": {
-                      "version": "0.0.3",
-                      "from": "component-inherit@0.0.3"
-                    },
-                    "debug": {
-                      "version": "1.0.4",
-                      "from": "debug@1.0.4",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.6.2",
-                          "from": "ms@0.6.2"
-                        }
-                      }
-                    },
-                    "engine.io-parser": {
-                      "version": "1.2.2",
-                      "from": "engine.io-parser@1.2.2",
-                      "dependencies": {
-                        "after": {
-                          "version": "0.8.1",
-                          "from": "after@0.8.1"
-                        },
-                        "arraybuffer.slice": {
-                          "version": "0.0.6",
-                          "from": "arraybuffer.slice@0.0.6"
-                        },
-                        "base64-arraybuffer": {
-                          "version": "0.1.2",
-                          "from": "base64-arraybuffer@0.1.2"
-                        },
-                        "blob": {
-                          "version": "0.0.4",
-                          "from": "blob@0.0.4"
-                        },
-                        "utf8": {
-                          "version": "2.1.0",
-                          "from": "utf8@2.1.0"
-                        }
-                      }
-                    },
-                    "has-cors": {
-                      "version": "1.0.3",
-                      "from": "has-cors@1.0.3",
-                      "dependencies": {
-                        "global": {
-                          "version": "2.0.1",
-                          "from": "https://github.com/component/global/archive/v2.0.1.tar.gz"
-                        }
-                      }
-                    },
-                    "parsejson": {
-                      "version": "0.0.1",
-                      "from": "parsejson@0.0.1",
-                      "dependencies": {
-                        "better-assert": {
-                          "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "from": "callsite@1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "parseqs": {
-                      "version": "0.0.2",
-                      "from": "parseqs@0.0.2",
-                      "dependencies": {
-                        "better-assert": {
-                          "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "from": "callsite@1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "parseuri": {
-                      "version": "0.0.4",
-                      "from": "parseuri@0.0.4",
-                      "dependencies": {
-                        "better-assert": {
-                          "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "from": "callsite@1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "ws": {
-                      "version": "0.8.0",
-                      "from": "ws@0.8.0",
-                      "dependencies": {
-                        "options": {
-                          "version": "0.0.6",
-                          "from": "options@>=0.0.5"
-                        },
-                        "ultron": {
-                          "version": "1.0.2",
-                          "from": "ultron@>=1.0.0 <1.1.0"
-                        },
-                        "bufferutil": {
-                          "version": "1.2.1",
-                          "from": "bufferutil@>=1.2.0 <1.3.0",
-                          "dependencies": {
-                            "bindings": {
-                              "version": "1.2.1",
-                              "from": "bindings@>=1.2.0 <1.3.0"
-                            },
-                            "nan": {
-                              "version": "2.1.0",
-                              "from": "nan@>=2.0.5 <3.0.0"
-                            }
-                          }
-                        },
-                        "utf-8-validate": {
-                          "version": "1.2.1",
-                          "from": "utf-8-validate@>=1.2.0 <1.3.0",
-                          "dependencies": {
-                            "bindings": {
-                              "version": "1.2.1",
-                              "from": "bindings@>=1.2.0 <1.3.0"
-                            },
-                            "nan": {
-                              "version": "2.1.0",
-                              "from": "nan@>=2.0.5 <3.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "xmlhttprequest": {
-                      "version": "1.5.0",
-                      "from": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
-                    }
-                  }
-                },
-                "component-bind": {
-                  "version": "1.0.0",
-                  "from": "component-bind@1.0.0"
-                },
-                "component-emitter": {
-                  "version": "1.1.2",
-                  "from": "component-emitter@1.1.2"
-                },
-                "object-component": {
-                  "version": "0.0.3",
-                  "from": "object-component@0.0.3"
-                },
-                "has-binary": {
-                  "version": "0.1.6",
-                  "from": "has-binary@0.1.6",
-                  "dependencies": {
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1"
-                    }
-                  }
-                },
-                "indexof": {
-                  "version": "0.0.1",
-                  "from": "indexof@0.0.1"
-                },
-                "parseuri": {
-                  "version": "0.0.2",
-                  "from": "parseuri@0.0.2",
-                  "dependencies": {
-                    "better-assert": {
-                      "version": "1.0.2",
-                      "from": "better-assert@>=1.0.0 <1.1.0",
-                      "dependencies": {
-                        "callsite": {
-                          "version": "1.0.0",
-                          "from": "callsite@1.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "to-array": {
-                  "version": "0.1.3",
-                  "from": "to-array@0.1.3"
-                },
-                "backo2": {
-                  "version": "1.0.2",
-                  "from": "backo2@1.0.2"
-                }
-              }
-            },
-            "socket.io-adapter": {
-              "version": "0.3.1",
-              "from": "socket.io-adapter@0.3.1",
-              "dependencies": {
-                "debug": {
-                  "version": "1.0.2",
-                  "from": "debug@1.0.2",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2"
-                    }
-                  }
-                },
-                "socket.io-parser": {
-                  "version": "2.2.2",
-                  "from": "socket.io-parser@2.2.2",
-                  "dependencies": {
-                    "debug": {
-                      "version": "0.7.4",
-                      "from": "debug@0.7.4"
-                    },
-                    "json3": {
-                      "version": "3.2.6",
-                      "from": "json3@3.2.6"
-                    },
-                    "component-emitter": {
-                      "version": "1.1.2",
-                      "from": "component-emitter@1.1.2"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1"
-                    },
-                    "benchmark": {
-                      "version": "1.0.0",
-                      "from": "benchmark@1.0.0"
-                    }
-                  }
-                },
-                "object-keys": {
-                  "version": "1.0.1",
-                  "from": "object-keys@1.0.1"
-                }
-              }
-            },
-            "has-binary-data": {
-              "version": "0.1.3",
-              "from": "has-binary-data@0.1.3",
-              "dependencies": {
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                }
-              }
-            },
-            "debug": {
-              "version": "2.1.0",
-              "from": "debug@2.1.0",
-              "dependencies": {
-                "ms": {
-                  "version": "0.6.2",
-                  "from": "ms@0.6.2"
-                }
-              }
-            }
-          }
-        },
-        "ua-parser-js": {
-          "version": "0.7.9",
-          "from": "ua-parser-js@>=0.7.9 <0.8.0"
-        },
-        "ucfirst": {
-          "version": "1.0.0",
-          "from": "ucfirst@>=1.0.0 <2.0.0"
-        }
-      }
-    },
-    "gulp": {
-      "version": "3.9.0",
-      "from": "gulp@>=3.8.8 <4.0.0",
-      "dependencies": {
-        "archy": {
-          "version": "1.0.0",
-          "from": "archy@>=1.0.0 <2.0.0"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0"
-            }
-          }
-        },
-        "deprecated": {
-          "version": "0.0.1",
-          "from": "deprecated@>=0.0.1 <0.0.2"
-        },
-        "interpret": {
-          "version": "0.6.6",
-          "from": "interpret@>=0.6.2 <0.7.0"
-        },
-        "liftoff": {
-          "version": "2.2.0",
-          "from": "liftoff@>=2.1.0 <3.0.0",
-          "dependencies": {
-            "extend": {
-              "version": "2.0.1",
-              "from": "extend@>=2.0.1 <3.0.0"
-            },
-            "findup-sync": {
-              "version": "0.3.0",
-              "from": "findup-sync@>=0.3.0 <0.4.0",
-              "dependencies": {
-                "glob": {
-                  "version": "5.0.15",
-                  "from": "glob@>=5.0.0 <5.1.0",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0"
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.1",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.1",
-                              "from": "balanced-match@>=0.2.0 <0.3.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "flagged-respawn": {
-              "version": "0.3.1",
-              "from": "flagged-respawn@>=0.3.1 <0.4.0"
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "from": "rechoir@>=0.6.0 <0.7.0"
-            },
-            "resolve": {
-              "version": "1.1.6",
-              "from": "resolve@>=1.1.6 <2.0.0"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0"
-        },
-        "orchestrator": {
-          "version": "0.3.7",
-          "from": "orchestrator@>=0.3.0 <0.4.0",
-          "dependencies": {
-            "end-of-stream": {
-              "version": "0.1.5",
-              "from": "end-of-stream@>=0.1.5 <0.2.0",
-              "dependencies": {
-                "once": {
-                  "version": "1.3.2",
-                  "from": "once@>=1.3.0 <1.4.0",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "sequencify": {
-              "version": "0.0.7",
-              "from": "sequencify@>=0.0.7 <0.1.0"
-            },
-            "stream-consume": {
-              "version": "0.1.0",
-              "from": "stream-consume@>=0.1.0 <0.2.0"
-            }
-          }
-        },
-        "pretty-hrtime": {
-          "version": "1.0.1",
-          "from": "pretty-hrtime@>=1.0.0 <2.0.0"
-        },
-        "semver": {
-          "version": "4.3.6",
-          "from": "semver@>=4.1.0 <5.0.0"
-        },
-        "tildify": {
-          "version": "1.1.2",
-          "from": "tildify@>=1.0.0 <2.0.0",
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1",
-              "from": "os-homedir@>=1.0.0 <2.0.0"
-            }
-          }
-        },
-        "v8flags": {
-          "version": "2.0.10",
-          "from": "v8flags@>=2.0.2 <3.0.0",
-          "dependencies": {
-            "user-home": {
-              "version": "1.1.1",
-              "from": "user-home@>=1.1.1 <2.0.0"
-            }
-          }
-        },
-        "vinyl-fs": {
-          "version": "0.3.14",
-          "from": "vinyl-fs@>=0.3.0 <0.4.0",
-          "dependencies": {
-            "defaults": {
-              "version": "1.0.3",
-              "from": "defaults@>=1.0.0 <2.0.0",
-              "dependencies": {
-                "clone": {
-                  "version": "1.0.2",
-                  "from": "clone@>=1.0.2 <2.0.0"
-                }
-              }
-            },
-            "glob-stream": {
-              "version": "3.1.18",
-              "from": "glob-stream@>=3.1.5 <4.0.0",
-              "dependencies": {
-                "glob": {
-                  "version": "4.5.3",
-                  "from": "glob@>=4.3.1 <5.0.0",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0"
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.1",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.1",
-                          "from": "balanced-match@>=0.2.0 <0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "ordered-read-streams": {
-                  "version": "0.1.0",
-                  "from": "ordered-read-streams@>=0.1.0 <0.2.0"
-                },
-                "glob2base": {
-                  "version": "0.0.12",
-                  "from": "glob2base@>=0.0.12 <0.0.13",
-                  "dependencies": {
-                    "find-index": {
-                      "version": "0.1.1",
-                      "from": "find-index@>=0.1.1 <0.2.0"
-                    }
-                  }
-                },
-                "unique-stream": {
-                  "version": "1.0.0",
-                  "from": "unique-stream@>=1.0.0 <2.0.0"
-                }
-              }
-            },
-            "glob-watcher": {
-              "version": "0.0.6",
-              "from": "glob-watcher@>=0.0.6 <0.0.7",
-              "dependencies": {
-                "gaze": {
-                  "version": "0.5.2",
-                  "from": "gaze@>=0.5.1 <0.6.0",
-                  "dependencies": {
-                    "globule": {
-                      "version": "0.1.0",
-                      "from": "globule@>=0.1.0 <0.2.0",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "1.0.2",
-                          "from": "lodash@>=1.0.1 <1.1.0"
-                        },
-                        "glob": {
-                          "version": "3.1.21",
-                          "from": "glob@>=3.1.21 <3.2.0",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "1.2.3",
-                              "from": "graceful-fs@>=1.2.0 <1.3.0"
-                            },
-                            "inherits": {
-                              "version": "1.0.2",
-                              "from": "inherits@>=1.0.0 <2.0.0"
-                            }
-                          }
-                        },
-                        "minimatch": {
-                          "version": "0.2.14",
-                          "from": "minimatch@>=0.2.11 <0.3.0",
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "2.7.0",
-                              "from": "lru-cache@>=2.0.0 <3.0.0"
-                            },
-                            "sigmund": {
-                              "version": "1.0.1",
-                              "from": "sigmund@>=1.0.0 <1.1.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.0 <4.0.0"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8"
-                }
-              }
-            },
-            "strip-bom": {
-              "version": "1.0.0",
-              "from": "strip-bom@>=1.0.0 <2.0.0",
-              "dependencies": {
-                "first-chunk-stream": {
-                  "version": "1.0.0",
-                  "from": "first-chunk-stream@>=1.0.0 <2.0.0"
-                },
-                "is-utf8": {
-                  "version": "0.2.0",
-                  "from": "is-utf8@>=0.2.0 <0.3.0"
-                }
-              }
-            },
-            "through2": {
-              "version": "0.6.5",
-              "from": "through2@>=0.6.1 <0.7.0",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.0",
-                  "from": "xtend@>=4.0.0 <4.1.0-0"
-                }
-              }
-            },
-            "vinyl": {
-              "version": "0.4.6",
-              "from": "vinyl@>=0.4.0 <0.5.0",
-              "dependencies": {
-                "clone": {
-                  "version": "0.2.0",
-                  "from": "clone@>=0.2.0 <0.3.0"
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.0.2"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-bump": {
-      "version": "0.3.1",
-      "from": "gulp-bump@>=0.3.1 <0.4.0",
-      "dependencies": {
-        "dot-object": {
-          "version": "0.6.0",
-          "from": "dot-object@>=0.6.0 <0.7.0",
-          "dependencies": {
-            "commander": {
-              "version": "2.9.0",
-              "from": "commander@>=2.5.0 <3.0.0",
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "semver": {
-          "version": "4.3.6",
-          "from": "semver@>=4.3.1 <5.0.0"
-        },
-        "through2": {
-          "version": "0.5.1",
-          "from": "through2@>=0.5.1 <0.6.0",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.17 <1.1.0",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                }
-              }
-            },
-            "xtend": {
-              "version": "3.0.0",
-              "from": "xtend@>=3.0.0 <3.1.0"
-            }
-          }
-        }
-      }
-    },
-    "gulp-filter": {
-      "version": "2.0.2",
-      "from": "gulp-filter@>=2.0.2 <3.0.0",
-      "dependencies": {
-        "merge-stream": {
-          "version": "0.1.8",
-          "from": "merge-stream@>=0.1.7 <0.2.0"
-        },
-        "multimatch": {
-          "version": "2.0.0",
-          "from": "multimatch@>=2.0.0 <3.0.0",
+        "gulp-util": {
+          "version": "3.0.7",
+          "from": "gulp-util@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "array-differ@>=1.0.0 <2.0.0"
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
-            "array-union": {
-              "version": "1.0.1",
-              "from": "array-union@>=1.0.1 <2.0.0",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "from": "array-uniq@>=1.0.1 <2.0.0"
-                }
-              }
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
             },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.1",
-                      "from": "balanced-match@>=0.2.0 <0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "plexer": {
-          "version": "0.0.3",
-          "from": "plexer@0.0.3",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "readable-stream@>=1.0.26-2 <2.0.0",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                }
-              }
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0"
-            }
-          }
-        }
-      }
-    },
-    "gulp-git": {
-      "version": "1.6.0",
-      "from": "gulp-git@>=1.2.4 <2.0.0",
-      "dependencies": {
-        "any-shell-escape": {
-          "version": "0.1.1",
-          "from": "any-shell-escape@>=0.1.1 <0.2.0"
-        },
-        "require-dir": {
-          "version": "0.1.0",
-          "from": "require-dir@>=0.1.0 <0.2.0"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.5 <0.7.0",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0"
-            }
-          }
-        }
-      }
-    },
-    "gulp-notify": {
-      "version": "2.2.0",
-      "from": "gulp-notify@>=2.2.0 <3.0.0",
-      "dependencies": {
-        "lodash.template": {
-          "version": "3.6.2",
-          "from": "lodash.template@>=3.0.0 <4.0.0",
-          "dependencies": {
-            "lodash._basecopy": {
-              "version": "3.0.1",
-              "from": "lodash._basecopy@>=3.0.0 <4.0.0"
-            },
-            "lodash._basetostring": {
-              "version": "3.0.1",
-              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
-            },
-            "lodash._basevalues": {
-              "version": "3.0.0",
-              "from": "lodash._basevalues@>=3.0.0 <4.0.0"
-            },
-            "lodash._isiterateecall": {
-              "version": "3.0.9",
-              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0"
-            },
-            "lodash._reinterpolate": {
-              "version": "3.0.0",
-              "from": "lodash._reinterpolate@>=3.0.0 <4.0.0"
-            },
-            "lodash.escape": {
-              "version": "3.0.0",
-              "from": "lodash.escape@>=3.0.0 <4.0.0"
-            },
-            "lodash.keys": {
-              "version": "3.1.2",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0"
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0"
-            },
-            "lodash.templatesettings": {
-              "version": "3.1.0",
-              "from": "lodash.templatesettings@>=3.0.0 <4.0.0"
-            }
-          }
-        },
-        "node-notifier": {
-          "version": "4.3.1",
-          "from": "node-notifier@>=4.1.0 <5.0.0",
-          "dependencies": {
-            "cli-usage": {
-              "version": "0.1.2",
-              "from": "cli-usage@>=0.1.1 <0.2.0",
-              "dependencies": {
-                "marked": {
-                  "version": "0.3.5",
-                  "from": "marked@>=0.3.2 <0.4.0"
-                },
-                "marked-terminal": {
-                  "version": "1.6.1",
-                  "from": "marked-terminal@>=1.6.1 <2.0.0",
-                  "dependencies": {
-                    "cardinal": {
-                      "version": "0.5.0",
-                      "from": "cardinal@>=0.5.0 <0.6.0",
-                      "dependencies": {
-                        "redeyed": {
-                          "version": "0.5.0",
-                          "from": "redeyed@>=0.5.0 <0.6.0",
-                          "dependencies": {
-                            "esprima-fb": {
-                              "version": "12001.1.0-dev-harmony-fb",
-                              "from": "esprima-fb@>=12001.1.0-dev-harmony-fb <12001.2.0"
-                            }
-                          }
-                        },
-                        "ansicolors": {
-                          "version": "0.2.1",
-                          "from": "ansicolors@>=0.2.1 <0.3.0"
-                        }
-                      }
-                    },
-                    "chalk": {
-                      "version": "1.1.1",
-                      "from": "chalk@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.1.0",
-                          "from": "ansi-styles@>=2.1.0 <3.0.0"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.3",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.0",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0"
-                        }
-                      }
-                    },
-                    "cli-table": {
-                      "version": "0.3.1",
-                      "from": "cli-table@>=0.3.1 <0.4.0",
-                      "dependencies": {
-                        "colors": {
-                          "version": "1.0.3",
-                          "from": "colors@1.0.3"
-                        }
-                      }
-                    },
-                    "lodash.assign": {
-                      "version": "3.2.0",
-                      "from": "lodash.assign@>=3.0.0 <4.0.0",
-                      "dependencies": {
-                        "lodash._baseassign": {
-                          "version": "3.2.0",
-                          "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-                          "dependencies": {
-                            "lodash._basecopy": {
-                              "version": "3.0.1",
-                              "from": "lodash._basecopy@>=3.0.0 <4.0.0"
-                            }
-                          }
-                        },
-                        "lodash._createassigner": {
-                          "version": "3.1.1",
-                          "from": "lodash._createassigner@>=3.0.0 <4.0.0",
-                          "dependencies": {
-                            "lodash._bindcallback": {
-                              "version": "3.0.1",
-                              "from": "lodash._bindcallback@>=3.0.0 <4.0.0"
-                            },
-                            "lodash._isiterateecall": {
-                              "version": "3.0.9",
-                              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0"
-                            },
-                            "lodash.restparam": {
-                              "version": "3.6.1",
-                              "from": "lodash.restparam@>=3.0.0 <4.0.0"
-                            }
-                          }
-                        },
-                        "lodash.keys": {
-                          "version": "3.1.2",
-                          "from": "lodash.keys@>=3.0.0 <4.0.0",
-                          "dependencies": {
-                            "lodash._getnative": {
-                              "version": "3.9.1",
-                              "from": "lodash._getnative@>=3.0.0 <4.0.0"
-                            },
-                            "lodash.isarguments": {
-                              "version": "3.0.4",
-                              "from": "lodash.isarguments@>=3.0.0 <4.0.0"
-                            },
-                            "lodash.isarray": {
-                              "version": "3.0.4",
-                              "from": "lodash.isarray@>=3.0.0 <4.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "node-emoji": {
-                      "version": "0.1.0",
-                      "from": "node-emoji@>=0.1.0 <0.2.0"
-                    }
-                  }
-                },
-                "minimist": {
-                  "version": "0.2.0",
-                  "from": "minimist@>=0.2.0 <0.3.0"
-                }
-              }
-            },
-            "growly": {
-              "version": "1.2.0",
-              "from": "growly@>=1.2.0 <2.0.0"
-            },
-            "lodash.clonedeep": {
-              "version": "3.0.2",
-              "from": "lodash.clonedeep@>=3.0.0 <4.0.0",
-              "dependencies": {
-                "lodash._baseclone": {
-                  "version": "3.3.0",
-                  "from": "lodash._baseclone@>=3.0.0 <4.0.0",
-                  "dependencies": {
-                    "lodash._arraycopy": {
-                      "version": "3.0.0",
-                      "from": "lodash._arraycopy@>=3.0.0 <4.0.0"
-                    },
-                    "lodash._arrayeach": {
-                      "version": "3.0.0",
-                      "from": "lodash._arrayeach@>=3.0.0 <4.0.0"
-                    },
-                    "lodash._baseassign": {
-                      "version": "3.2.0",
-                      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-                      "dependencies": {
-                        "lodash._basecopy": {
-                          "version": "3.0.1",
-                          "from": "lodash._basecopy@>=3.0.0 <4.0.0"
-                        }
-                      }
-                    },
-                    "lodash._basefor": {
-                      "version": "3.0.2",
-                      "from": "lodash._basefor@>=3.0.0 <4.0.0"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0"
-                    },
-                    "lodash.keys": {
-                      "version": "3.1.2",
-                      "from": "lodash.keys@>=3.0.0 <4.0.0",
-                      "dependencies": {
-                        "lodash._getnative": {
-                          "version": "3.9.1",
-                          "from": "lodash._getnative@>=3.0.0 <4.0.0"
-                        },
-                        "lodash.isarguments": {
-                          "version": "3.0.4",
-                          "from": "lodash.isarguments@>=3.0.0 <4.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash._bindcallback": {
-                  "version": "3.0.1",
-                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0"
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.1.1 <2.0.0"
-            },
-            "semver": {
-              "version": "4.3.6",
-              "from": "semver@>=4.0.3 <5.0.0"
-            },
-            "shellwords": {
-              "version": "0.1.0",
-              "from": "shellwords@>=0.1.0 <0.2.0"
-            },
-            "which": {
-              "version": "1.2.0",
-              "from": "which@>=1.0.5 <2.0.0",
-              "dependencies": {
-                "is-absolute": {
-                  "version": "0.1.7",
-                  "from": "is-absolute@>=0.1.7 <0.2.0",
-                  "dependencies": {
-                    "is-relative": {
-                      "version": "0.1.3",
-                      "from": "is-relative@>=0.1.0 <0.2.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "node.extend": {
-          "version": "1.1.5",
-          "from": "node.extend@>=1.1.3 <2.0.0",
-          "dependencies": {
-            "is": {
-              "version": "3.1.0",
-              "from": "is@>=3.0.1 <4.0.0"
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0"
-            }
-          }
-        }
-      }
-    },
-    "gulp-sass": {
-      "version": "2.1.0",
-      "from": "gulp-sass@>=2.0.2 <3.0.0",
-      "dependencies": {
-        "node-sass": {
-          "version": "3.3.3",
-          "from": "node-sass@>=3.3.3",
-          "dependencies": {
-            "async-foreach": {
-              "version": "0.1.3",
-              "from": "async-foreach@>=0.1.3 <0.2.0"
+            "beeper": {
+              "version": "1.1.0",
+              "from": "beeper@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
             },
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.1.1 <2.0.0",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0"
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
                   "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0"
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
                   "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0"
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0"
-                }
-              }
-            },
-            "cross-spawn": {
-              "version": "2.0.0",
-              "from": "cross-spawn@>=2.0.0 <3.0.0",
-              "dependencies": {
-                "cross-spawn-async": {
-                  "version": "2.0.0",
-                  "from": "cross-spawn-async@>=2.0.0 <3.0.0",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.0",
-                      "from": "lru-cache@>=2.6.5 <3.0.0"
-                    },
-                    "which": {
-                      "version": "1.2.0",
-                      "from": "which@>=1.1.1 <2.0.0",
-                      "dependencies": {
-                        "is-absolute": {
-                          "version": "0.1.7",
-                          "from": "is-absolute@>=0.1.7 <0.2.0",
-                          "dependencies": {
-                            "is-relative": {
-                              "version": "0.1.3",
-                              "from": "is-relative@>=0.1.0 <0.2.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "spawn-sync": {
-                  "version": "1.0.13",
-                  "from": "spawn-sync@>=1.0.13 <2.0.0",
-                  "dependencies": {
-                    "concat-stream": {
-                      "version": "1.5.1",
-                      "from": "concat-stream@>=1.4.7 <2.0.0",
-                      "dependencies": {
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0"
-                        },
-                        "typedarray": {
-                          "version": "0.0.6",
-                          "from": "typedarray@>=0.0.5 <0.1.0"
-                        },
-                        "readable-stream": {
-                          "version": "2.0.3",
-                          "from": "readable-stream@>=2.0.0 <2.1.0",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1"
-                            },
-                            "process-nextick-args": {
-                              "version": "1.0.3",
-                              "from": "process-nextick-args@>=1.0.0 <1.1.0"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0"
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.2",
-                              "from": "util-deprecate@>=1.0.1 <1.1.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "os-shim": {
-                      "version": "0.1.3",
-                      "from": "os-shim@>=0.1.2 <0.2.0"
-                    }
-                  }
-                }
-              }
-            },
-            "gaze": {
-              "version": "0.5.2",
-              "from": "gaze@>=0.5.1 <0.6.0",
-              "dependencies": {
-                "globule": {
-                  "version": "0.1.0",
-                  "from": "globule@>=0.1.0 <0.2.0",
-                  "dependencies": {
-                    "lodash": {
-                      "version": "1.0.2",
-                      "from": "lodash@>=1.0.1 <1.1.0"
-                    },
-                    "glob": {
-                      "version": "3.1.21",
-                      "from": "glob@>=3.1.21 <3.2.0",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "1.2.3",
-                          "from": "graceful-fs@>=1.2.0 <1.3.0"
-                        },
-                        "inherits": {
-                          "version": "1.0.2",
-                          "from": "inherits@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "minimatch@>=0.2.11 <0.3.0",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.7.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0"
-                        },
-                        "sigmund": {
-                          "version": "1.0.1",
-                          "from": "sigmund@>=1.0.0 <1.1.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0"
-            },
-            "glob": {
-              "version": "5.0.15",
-              "from": "glob@>=5.0.14 <6.0.0",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.1",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.1",
-                          "from": "balanced-match@>=0.2.0 <0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0"
-                }
-              }
-            },
-            "meow": {
-              "version": "3.4.2",
-              "from": "meow@>=3.3.0 <4.0.0",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "from": "camelcase@>=1.0.1 <2.0.0"
-                    },
-                    "map-obj": {
-                      "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "loud-rejection": {
-                  "version": "1.0.0",
-                  "from": "loud-rejection@>=1.0.0 <2.0.0"
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@>=1.1.3 <2.0.0"
-                },
-                "normalize-package-data": {
-                  "version": "2.3.4",
-                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
-                  "dependencies": {
-                    "hosted-git-info": {
-                      "version": "2.1.4",
-                      "from": "hosted-git-info@>=2.0.2 <3.0.0"
-                    },
-                    "is-builtin-module": {
-                      "version": "1.0.0",
-                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "builtin-modules": {
-                          "version": "1.1.0",
-                          "from": "builtin-modules@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    },
-                    "semver": {
-                      "version": "5.0.3",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0"
-                    },
-                    "validate-npm-package-license": {
-                      "version": "3.0.1",
-                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                      "dependencies": {
-                        "spdx-correct": {
-                          "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
-                          "dependencies": {
-                            "spdx-license-ids": {
-                              "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0"
-                            }
-                          }
-                        },
-                        "spdx-expression-parse": {
-                          "version": "1.0.0",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "dependencies": {
-                            "spdx-exceptions": {
-                              "version": "1.0.3",
-                              "from": "spdx-exceptions@>=1.0.0 <2.0.0"
-                            },
-                            "spdx-license-ids": {
-                              "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.0.0",
-                      "from": "find-up@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "path-exists": {
-                          "version": "2.0.0",
-                          "from": "path-exists@>=2.0.0 <3.0.0"
-                        },
-                        "pinkie-promise": {
-                          "version": "1.0.0",
-                          "from": "pinkie-promise@>=1.0.0 <2.0.0",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "1.0.0",
-                              "from": "pinkie@>=1.0.0 <2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "1.1.0",
-                      "from": "read-pkg@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "1.0.1",
-                          "from": "load-json-file@>=1.0.0 <2.0.0",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0"
-                            },
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "from": "parse-json@>=2.2.0 <3.0.0",
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.2.0",
-                                  "from": "error-ex@>=1.2.0 <2.0.0"
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0"
-                            },
-                            "pinkie-promise": {
-                              "version": "1.0.0",
-                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "1.0.0",
-                                  "from": "pinkie@>=1.0.0 <2.0.0"
-                                }
-                              }
-                            },
-                            "strip-bom": {
-                              "version": "2.0.0",
-                              "from": "strip-bom@>=2.0.0 <3.0.0",
-                              "dependencies": {
-                                "is-utf8": {
-                                  "version": "0.2.0",
-                                  "from": "is-utf8@>=0.2.0 <0.3.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "1.0.0",
-                          "from": "path-type@>=1.0.0 <2.0.0",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0"
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0"
-                            },
-                            "pinkie-promise": {
-                              "version": "1.0.0",
-                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "1.0.0",
-                                  "from": "pinkie@>=1.0.0 <2.0.0"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "redent": {
-                  "version": "1.0.0",
-                  "from": "redent@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "indent-string": {
-                      "version": "2.1.0",
-                      "from": "indent-string@>=2.1.0 <3.0.0",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "2.0.0",
-                          "from": "repeating@>=2.0.0 <3.0.0",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-indent": {
-                      "version": "1.0.1",
-                      "from": "strip-indent@>=1.0.1 <2.0.0"
-                    }
-                  }
-                },
-                "trim-newlines": {
-                  "version": "1.0.0",
-                  "from": "trim-newlines@>=1.0.0 <2.0.0"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8"
-                }
-              }
-            },
-            "nan": {
-              "version": "2.1.0",
-              "from": "nan@>=2.0.8 <3.0.0"
-            },
-            "npmconf": {
-              "version": "2.1.2",
-              "from": "npmconf@>=2.1.2 <3.0.0",
-              "dependencies": {
-                "config-chain": {
-                  "version": "1.1.9",
-                  "from": "config-chain@>=1.1.8 <1.2.0",
-                  "dependencies": {
-                    "proto-list": {
-                      "version": "1.2.4",
-                      "from": "proto-list@>=1.2.1 <1.3.0"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <2.1.0"
-                },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@>=1.2.0 <2.0.0"
-                },
-                "nopt": {
-                  "version": "3.0.4",
-                  "from": "nopt@>=3.0.1 <3.1.0",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "once@>=1.3.0 <1.4.0",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0"
-                    },
-                    "os-tmpdir": {
-                      "version": "1.0.1",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "4.3.6",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0"
-                },
-                "uid-number": {
-                  "version": "0.0.5",
-                  "from": "uid-number@0.0.5"
-                }
-              }
-            },
-            "node-gyp": {
-              "version": "3.0.3",
-              "from": "node-gyp@>=3.0.1 <4.0.0",
-              "dependencies": {
-                "fstream": {
-                  "version": "1.0.8",
-                  "from": "fstream@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <2.1.0"
-                    }
-                  }
-                },
-                "glob": {
-                  "version": "4.5.3",
-                  "from": "glob@>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0"
-                    },
-                    "minimatch": {
-                      "version": "2.0.10",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.1",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.1",
-                              "from": "balanced-match@>=0.2.0 <0.3.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0"
-                },
-                "minimatch": {
-                  "version": "1.0.0",
-                  "from": "minimatch@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0"
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "3.0.4",
-                  "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "npmlog": {
-                  "version": "1.2.1",
-                  "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "ansi": {
-                      "version": "0.3.0",
-                      "from": "ansi@>=0.3.0 <0.4.0"
-                    },
-                    "are-we-there-yet": {
-                      "version": "1.0.4",
-                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
-                      "dependencies": {
-                        "delegates": {
-                          "version": "0.1.0",
-                          "from": "delegates@>=0.1.0 <0.2.0"
-                        },
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "from": "readable-stream@>=1.1.13 <2.0.0",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "gauge": {
-                      "version": "1.2.2",
-                      "from": "gauge@>=1.2.0 <1.3.0",
-                      "dependencies": {
-                        "has-unicode": {
-                          "version": "1.0.1",
-                          "from": "has-unicode@>=1.0.0 <2.0.0"
-                        },
-                        "lodash.pad": {
-                          "version": "3.1.1",
-                          "from": "lodash.pad@>=3.0.0 <4.0.0",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1",
-                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1",
-                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.padleft": {
-                          "version": "3.1.1",
-                          "from": "lodash.padleft@>=3.0.0 <4.0.0",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1",
-                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1",
-                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.padright": {
-                          "version": "3.1.1",
-                          "from": "lodash.padright@>=3.0.0 <4.0.0",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1",
-                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1",
-                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "from": "osenv@>=0.0.0 <1.0.0",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0"
-                    },
-                    "os-tmpdir": {
-                      "version": "1.0.1",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "path-array": {
-                  "version": "1.0.0",
-                  "from": "path-array@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "array-index": {
-                      "version": "0.1.1",
-                      "from": "array-index@>=0.1.0 <0.2.0",
-                      "dependencies": {
-                        "debug": {
-                          "version": "2.2.0",
-                          "from": "debug@*",
-                          "dependencies": {
-                            "ms": {
-                              "version": "0.7.1",
-                              "from": "ms@0.7.1"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.4.3",
-                  "from": "rimraf@>=2.0.0 <3.0.0",
-                  "dependencies": {
-                    "glob": {
-                      "version": "5.0.15",
-                      "from": "glob@>=5.0.14 <6.0.0",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "from": "inflight@>=1.0.4 <2.0.0",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0"
-                        },
-                        "minimatch": {
-                          "version": "3.0.0",
-                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.1",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.2.1",
-                                  "from": "balanced-match@>=0.2.0 <0.3.0"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "concat-map@0.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.3.2",
-                          "from": "once@>=1.3.0 <2.0.0",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0"
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.0",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "5.0.3",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0"
-                },
-                "tar": {
-                  "version": "1.0.3",
-                  "from": "tar@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "block-stream": {
-                      "version": "0.0.8",
-                      "from": "block-stream@*"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0"
-                    }
-                  }
-                },
-                "which": {
-                  "version": "1.2.0",
-                  "from": "which@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "is-absolute": {
-                      "version": "0.1.7",
-                      "from": "is-absolute@>=0.1.7 <0.2.0",
-                      "dependencies": {
-                        "is-relative": {
-                          "version": "0.1.3",
-                          "from": "is-relative@>=0.1.0 <0.2.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "request": {
-              "version": "2.65.0",
-              "from": "request@>=2.61.0 <3.0.0",
-              "dependencies": {
-                "bl": {
-                  "version": "1.0.0",
-                  "from": "bl@>=1.0.0 <1.1.0",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.3",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.3",
-                          "from": "process-nextick-args@>=1.0.0 <1.1.0"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "caseless": {
-                  "version": "0.11.0",
-                  "from": "caseless@>=0.11.0 <0.12.0"
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "from": "extend@>=3.0.0 <3.1.0"
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "from": "forever-agent@>=0.6.1 <0.7.0"
-                },
-                "form-data": {
-                  "version": "1.0.0-rc3",
-                  "from": "form-data@>=1.0.0-rc3 <1.1.0",
-                  "dependencies": {
-                    "async": {
-                      "version": "1.5.0",
-                      "from": "async@>=1.4.0 <2.0.0"
-                    }
-                  }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.1 <5.1.0"
-                },
-                "mime-types": {
-                  "version": "2.1.7",
-                  "from": "mime-types@>=2.1.7 <2.2.0",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.19.0",
-                      "from": "mime-db@>=1.19.0 <1.20.0"
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.3 <1.5.0"
-                },
-                "qs": {
-                  "version": "5.2.0",
-                  "from": "qs@>=5.2.0 <5.3.0"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.1",
-                  "from": "tunnel-agent@>=0.4.1 <0.5.0"
-                },
-                "tough-cookie": {
-                  "version": "2.2.0",
-                  "from": "tough-cookie@>=2.2.0 <2.3.0"
-                },
-                "http-signature": {
-                  "version": "0.11.0",
-                  "from": "http-signature@>=0.11.0 <0.12.0",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11"
-                    },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "ctype@0.5.3"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.0",
-                  "from": "oauth-sign@>=0.8.0 <0.9.0"
-                },
-                "hawk": {
-                  "version": "3.1.0",
-                  "from": "hawk@>=3.1.0 <3.2.0",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "hoek@>=2.0.0 <3.0.0"
-                    },
-                    "boom": {
-                      "version": "2.10.0",
-                      "from": "boom@>=2.8.0 <3.0.0"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "cryptiles@>=2.0.0 <3.0.0"
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "from": "aws-sign2@>=0.6.0 <0.7.0"
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "from": "stringstream@>=0.0.4 <0.1.0"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "from": "combined-stream@>=1.0.5 <1.1.0",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "delayed-stream@>=1.0.0 <1.1.0"
-                    }
-                  }
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "from": "isstream@>=0.1.2 <0.2.0"
-                },
-                "har-validator": {
-                  "version": "2.0.2",
-                  "from": "har-validator@>=2.0.2 <2.1.0",
-                  "dependencies": {
-                    "commander": {
-                      "version": "2.9.0",
-                      "from": "commander@>=2.8.1 <3.0.0",
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1",
-                          "from": "graceful-readlink@>=1.0.0"
-                        }
-                      }
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.12.2",
-                      "from": "is-my-json-valid@>=2.12.2 <3.0.0",
-                      "dependencies": {
-                        "generate-function": {
-                          "version": "2.0.0",
-                          "from": "generate-function@>=2.0.0 <3.0.0"
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0",
-                          "from": "generate-object-property@>=1.1.0 <2.0.0",
-                          "dependencies": {
-                            "is-property": {
-                              "version": "1.0.2",
-                              "from": "is-property@>=1.0.0 <2.0.0"
-                            }
-                          }
-                        },
-                        "jsonpointer": {
-                          "version": "2.0.0",
-                          "from": "jsonpointer@2.0.0"
-                        },
-                        "xtend": {
-                          "version": "4.0.0",
-                          "from": "xtend@>=4.0.0 <5.0.0"
-                        }
-                      }
-                    },
-                    "pinkie-promise": {
-                      "version": "1.0.0",
-                      "from": "pinkie-promise@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "1.0.0",
-                          "from": "pinkie@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "sass-graph": {
-              "version": "2.0.1",
-              "from": "sass-graph@>=2.0.1 <3.0.0",
-              "dependencies": {
-                "lodash": {
-                  "version": "3.10.1",
-                  "from": "lodash@>=3.8.0 <4.0.0"
-                },
-                "yargs": {
-                  "version": "3.29.0",
-                  "from": "yargs@>=3.8.0 <4.0.0",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "from": "camelcase@>=1.2.1 <2.0.0"
-                    },
-                    "cliui": {
-                      "version": "3.0.3",
-                      "from": "cliui@>=3.0.3 <4.0.0",
-                      "dependencies": {
-                        "string-width": {
-                          "version": "1.0.1",
-                          "from": "string-width@>=1.0.1 <2.0.0",
-                          "dependencies": {
-                            "code-point-at": {
-                              "version": "1.0.0",
-                              "from": "code-point-at@>=1.0.0 <2.0.0",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0"
-                                }
-                              }
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "1.0.0",
-                              "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.0",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0"
-                            }
-                          }
-                        },
-                        "wrap-ansi": {
-                          "version": "1.0.0",
-                          "from": "wrap-ansi@>=1.0.0 <2.0.0"
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.1.1",
-                      "from": "decamelize@>=1.0.0 <2.0.0"
-                    },
-                    "os-locale": {
-                      "version": "1.4.0",
-                      "from": "os-locale@>=1.4.0 <2.0.0",
-                      "dependencies": {
-                        "lcid": {
-                          "version": "1.0.0",
-                          "from": "lcid@>=1.0.0 <2.0.0",
-                          "dependencies": {
-                            "invert-kv": {
-                              "version": "1.0.0",
-                              "from": "invert-kv@>=1.0.0 <2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "window-size": {
-                      "version": "0.1.2",
-                      "from": "window-size@>=0.1.2 <0.2.0"
-                    },
-                    "y18n": {
-                      "version": "3.2.0",
-                      "from": "y18n@>=3.2.0 <4.0.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0"
-        },
-        "through2": {
-          "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.3",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.3",
-                  "from": "process-nextick-args@>=1.0.0 <1.1.0"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0"
-            }
-          }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.2.0",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0"
-            }
-          }
-        }
-      }
-    },
-    "gulp-scss-lint": {
-      "version": "0.1.12",
-      "from": "gulp-scss-lint@>=0.1.6 <0.2.0",
-      "dependencies": {
-        "dargs": {
-          "version": "3.0.1",
-          "from": "dargs@>=3.0.0 <3.1.0"
-        },
-        "event-stream": {
-          "version": "3.2.2",
-          "from": "event-stream@>=3.2.2 <3.3.0",
-          "dependencies": {
-            "through": {
-              "version": "2.3.8",
-              "from": "through@>=2.3.1 <2.4.0"
-            },
-            "duplexer": {
-              "version": "0.1.1",
-              "from": "duplexer@>=0.1.1 <0.2.0"
-            },
-            "from": {
-              "version": "0.1.3",
-              "from": "from@>=0.0.0 <1.0.0"
-            },
-            "map-stream": {
-              "version": "0.1.0",
-              "from": "map-stream@>=0.1.0 <0.2.0"
-            },
-            "pause-stream": {
-              "version": "0.0.11",
-              "from": "pause-stream@0.0.11"
-            },
-            "split": {
-              "version": "0.3.3",
-              "from": "split@>=0.3.0 <0.4.0"
-            },
-            "stream-combiner": {
-              "version": "0.0.4",
-              "from": "stream-combiner@>=0.0.4 <0.1.0"
-            }
-          }
-        },
-        "sync-exec": {
-          "version": "0.5.0",
-          "from": "sync-exec@>=0.5.0 <0.6.0"
-        },
-        "pretty-data": {
-          "version": "0.40.0",
-          "from": "pretty-data@>=0.40.0 <0.41.0"
-        },
-        "xml2js": {
-          "version": "0.4.13",
-          "from": "xml2js@>=0.4.4 <0.5.0",
-          "dependencies": {
-            "sax": {
-              "version": "1.1.4",
-              "from": "sax@>=0.6.0"
-            },
-            "xmlbuilder": {
-              "version": "3.1.0",
-              "from": "xmlbuilder@>=2.4.6",
-              "dependencies": {
-                "lodash": {
-                  "version": "3.10.1",
-                  "from": "lodash@>=3.5.0 <4.0.0"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-shrinkwrap": {
-      "version": "2.0.1",
-      "from": "gulp-shrinkwrap@>=2.0.1 <3.0.0",
-      "dependencies": {
-        "bluebird": {
-          "version": "2.9.14",
-          "from": "bluebird@2.9.14"
-        },
-        "graceful-fs": {
-          "version": "3.0.6",
-          "from": "graceful-fs@3.0.6"
-        },
-        "gulp-util": {
-          "version": "3.0.4",
-          "from": "gulp-util@3.0.4",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "from": "array-differ@1.0.0"
-            },
-            "array-uniq": {
-              "version": "1.0.2",
-              "from": "array-uniq@1.0.2"
-            },
-            "beeper": {
-              "version": "1.0.0",
-              "from": "beeper@1.0.0"
-            },
-            "chalk": {
-              "version": "1.0.0",
-              "from": "chalk@1.0.0",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.0.1",
-                  "from": "ansi-styles@2.0.1"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@1.0.3"
-                },
-                "has-ansi": {
-                  "version": "1.0.3",
-                  "from": "has-ansi@1.0.3",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@1.1.1"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "get-stdin@4.0.1"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "2.0.1",
-                  "from": "strip-ansi@2.0.1",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@1.1.1"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "1.3.0",
-                  "from": "supports-color@1.3.0"
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "dateformat": {
               "version": "1.0.11",
-              "from": "dateformat@1.0.11",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@4.0.1"
-                },
-                "meow": {
-                  "version": "3.1.0",
-                  "from": "meow@3.1.0",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "from": "camelcase-keys@1.0.0",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.0.2",
-                          "from": "camelcase@1.0.2"
-                        },
-                        "map-obj": {
-                          "version": "1.0.0",
-                          "from": "map-obj@1.0.0"
-                        }
-                      }
-                    },
-                    "indent-string": {
-                      "version": "1.2.1",
-                      "from": "indent-string@1.2.1",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "1.1.2",
-                          "from": "repeating@1.1.2",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.0",
-                              "from": "is-finite@1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._reescape": {
-              "version": "3.0.0",
-              "from": "lodash._reescape@3.0.0"
-            },
-            "lodash._reevaluate": {
-              "version": "3.0.0",
-              "from": "lodash._reevaluate@3.0.0"
-            },
-            "lodash._reinterpolate": {
-              "version": "3.0.0",
-              "from": "lodash._reinterpolate@3.0.0"
-            },
-            "lodash.template": {
-              "version": "3.3.2",
-              "from": "lodash.template@3.3.2",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.0",
-                  "from": "lodash._basecopy@3.0.0"
-                },
-                "lodash._basetostring": {
-                  "version": "3.0.0",
-                  "from": "lodash._basetostring@3.0.0"
-                },
-                "lodash._basevalues": {
-                  "version": "3.0.0",
-                  "from": "lodash._basevalues@3.0.0"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.4",
-                  "from": "lodash._isiterateecall@3.0.4"
-                },
-                "lodash.escape": {
-                  "version": "3.0.0",
-                  "from": "lodash.escape@3.0.0"
-                },
-                "lodash.keys": {
-                  "version": "3.0.4",
-                  "from": "lodash.keys@3.0.4",
-                  "dependencies": {
-                    "lodash.isarguments": {
-                      "version": "3.0.0",
-                      "from": "lodash.isarguments@3.0.0"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.0",
-                      "from": "lodash.isarray@3.0.0"
-                    },
-                    "lodash.isnative": {
-                      "version": "3.0.0",
-                      "from": "lodash.isnative@3.0.0"
-                    }
-                  }
-                },
-                "lodash.templatesettings": {
-                  "version": "3.1.0",
-                  "from": "lodash.templatesettings@3.1.0"
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.1.1",
-              "from": "minimist@1.1.1"
-            },
-            "multipipe": {
-              "version": "0.1.2",
-              "from": "multipipe@0.1.2",
-              "dependencies": {
-                "duplexer2": {
-                  "version": "0.0.2",
-                  "from": "duplexer2@0.0.2",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "from": "readable-stream@1.1.13",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@1.0.1"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@2.0.1"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.0.0",
-              "from": "object-assign@2.0.0"
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "replace-ext@0.0.1"
-            },
-            "vinyl": {
-              "version": "0.4.6",
-              "from": "vinyl@0.4.6",
-              "dependencies": {
-                "clone": {
-                  "version": "0.2.0",
-                  "from": "clone@0.2.0"
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "from": "clone-stats@0.0.1"
-                }
-              }
-            }
-          }
-        },
-        "lodash": {
-          "version": "3.1.0",
-          "from": "lodash@3.1.0"
-        },
-        "npm": {
-          "version": "2.7.0",
-          "from": "npm@2.7.0",
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.5",
-              "from": "abbrev@latest"
-            },
-            "ansi": {
-              "version": "0.3.0",
-              "from": "ansi@latest"
-            },
-            "ansicolors": {
-              "version": "0.3.2",
-              "from": "ansicolors@latest"
-            },
-            "ansistyles": {
-              "version": "0.1.3",
-              "from": "ansistyles@0.1.3"
-            },
-            "archy": {
-              "version": "1.0.0",
-              "from": "archy@>=1.0.0 <2.0.0"
-            },
-            "async-some": {
-              "version": "1.0.1",
-              "from": "async-some@>=1.0.1-0 <2.0.0-0"
-            },
-            "block-stream": {
-              "version": "0.0.7",
-              "from": "block-stream@latest"
-            },
-            "char-spinner": {
-              "version": "1.0.1",
-              "from": "char-spinner@latest"
-            },
-            "child-process-close": {
-              "version": "0.1.1",
-              "from": "child-process-close@"
-            },
-            "chmodr": {
-              "version": "0.1.0",
-              "from": "chmodr@latest"
-            },
-            "chownr": {
-              "version": "0.0.1",
-              "from": "../chownr"
-            },
-            "cmd-shim": {
-              "version": "2.0.1",
-              "from": "cmd-shim@>=2.0.1-0 <3.0.0-0"
-            },
-            "columnify": {
-              "version": "1.4.1",
-              "from": "columnify@>=1.4.1 <1.5.0",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "2.0.1",
-                  "from": "strip-ansi@>=2.0.0 <3.0.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.0",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "wcwidth": {
-                  "version": "1.0.0",
-                  "from": "wcwidth@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "defaults": {
-                      "version": "1.0.0",
-                      "from": "defaults@>=1.0.0 <2.0.0",
-                      "dependencies": {
-                        "clone": {
-                          "version": "0.1.19",
-                          "from": "clone@>=0.1.5 <0.2.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "config-chain": {
-              "version": "1.1.8",
-              "from": "config-chain@^1.1.8",
-              "dependencies": {
-                "proto-list": {
-                  "version": "1.2.3",
-                  "from": "proto-list@~1.2.1"
-                }
-              }
-            },
-            "dezalgo": {
-              "version": "1.0.1",
-              "from": "dezalgo@latest",
-              "dependencies": {
-                "asap": {
-                  "version": "1.0.0",
-                  "from": "asap@>=1.0.0 <2.0.0"
-                }
-              }
-            },
-            "editor": {
-              "version": "0.1.0",
-              "from": "editor@latest"
-            },
-            "fs-vacuum": {
-              "version": "1.2.5",
-              "from": "fs-vacuum@~1.2.5"
-            },
-            "fs-write-stream-atomic": {
-              "version": "1.0.2",
-              "from": "fs-write-stream-atomic@>=1.0.2 <1.1.0"
-            },
-            "fstream": {
-              "version": "1.0.4",
-              "from": "fstream@>=1.0.4 <1.1.0"
-            },
-            "fstream-npm": {
-              "version": "1.0.1",
-              "from": "fstream-npm@1.0.1",
-              "dependencies": {
-                "fstream-ignore": {
-                  "version": "1.0.2",
-                  "from": "fstream-ignore@>=1.0.0 <2.0.0"
-                }
-              }
-            },
-            "github-url-from-git": {
-              "version": "1.4.0",
-              "from": "github-url-from-git@>=1.4.0-0 <2.0.0-0"
-            },
-            "github-url-from-username-repo": {
-              "version": "1.0.2",
-              "from": "github-url-from-username-repo@>=1.0.2-0 <2.0.0-0"
-            },
-            "glob": {
-              "version": "4.4.1",
-              "from": "glob@>=4.4.1 <4.5.0"
-            },
-            "graceful-fs": {
-              "version": "3.0.5",
-              "from": "graceful-fs@>=3.0.5 <3.1.0"
-            },
-            "inflight": {
-              "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <1.1.0"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@latest"
-            },
-            "ini": {
-              "version": "1.3.3",
-              "from": "ini@>=1.3.1 <1.4.0"
-            },
-            "init-package-json": {
-              "version": "1.3.0",
-              "from": "init-package-json@>=1.3.0 <1.4.0",
-              "dependencies": {
-                "promzard": {
-                  "version": "0.2.2",
-                  "from": "promzard@>=0.2.0 <0.3.0"
-                }
-              }
-            },
-            "lockfile": {
-              "version": "1.0.0",
-              "from": "lockfile@1.0.0"
-            },
-            "lru-cache": {
-              "version": "2.5.0",
-              "from": "lru-cache@latest"
-            },
-            "minimatch": {
-              "version": "2.0.1",
-              "from": "minimatch@>=2.0.1 <2.1.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.0.1",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.0",
-                      "from": "concat-map@0.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.0",
-              "from": "mkdirp@latest",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8"
-                }
-              }
-            },
-            "node-gyp": {
-              "version": "1.0.2",
-              "from": "node-gyp@>=1.0.2 <1.1.0",
-              "dependencies": {
-                "minimatch": {
-                  "version": "1.0.0",
-                  "from": "minimatch@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0"
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.1",
-              "from": "nopt@latest"
-            },
-            "normalize-git-url": {
-              "version": "1.0.0",
-              "from": "normalize-git-url@>=1.0.0 <1.1.0"
-            },
-            "normalize-package-data": {
-              "version": "1.0.3",
-              "from": "normalize-package-data@>=1.0.3 <1.1.0"
-            },
-            "npm-cache-filename": {
-              "version": "1.0.1",
-              "from": "npm-cache-filename@latest"
-            },
-            "npm-install-checks": {
-              "version": "1.0.5",
-              "from": "npm-install-checks@>=1.0.5 <1.1.0"
-            },
-            "npm-package-arg": {
-              "version": "2.1.3",
-              "from": "npm-package-arg@~2.1.3"
-            },
-            "npm-registry-client": {
-              "version": "6.1.1",
-              "from": "npm-registry-client@>=6.1.1 <6.2.0",
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.4.7",
-                  "from": "concat-stream@>=1.4.6 <2.0.0",
-                  "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "from": "typedarray@>=0.0.5 <0.1.0"
-                    },
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "from": "readable-stream@>=1.1.9 <1.2.0",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "npm-package-arg": {
-                  "version": "3.1.0",
-                  "from": "npm-package-arg@>=3.0.0 <4.0.0",
-                  "dependencies": {
-                    "hosted-git-info": {
-                      "version": "1.5.3",
-                      "from": "hosted-git-info@>=1.5.3 <2.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "npm-user-validate": {
-              "version": "0.1.1",
-              "from": "npm-user-validate@>=0.1.1 <0.2.0"
-            },
-            "npmlog": {
-              "version": "0.1.1",
-              "from": "npmlog@latest"
-            },
-            "once": {
-              "version": "1.3.1",
-              "from": "once@>=1.3.1 <2.0.0"
-            },
-            "opener": {
-              "version": "1.4.0",
-              "from": "opener@>=1.4.0 <1.5.0"
-            },
-            "osenv": {
-              "version": "0.1.0",
-              "from": "osenv@~0.1.0"
-            },
-            "path-is-inside": {
-              "version": "1.0.1",
-              "from": "path-is-inside@1.0.1"
-            },
-            "read": {
-              "version": "1.0.5",
-              "from": "read@latest",
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.4",
-                  "from": "mute-stream@~0.0.4"
-                }
-              }
-            },
-            "read-installed": {
-              "version": "3.1.5",
-              "from": "read-installed@>=3.1.5 <3.2.0",
-              "dependencies": {
-                "debuglog": {
-                  "version": "1.0.1",
-                  "from": "debuglog@>=1.0.1 <2.0.0"
-                },
-                "readdir-scoped-modules": {
-                  "version": "1.0.1",
-                  "from": "readdir-scoped-modules@>=1.0.0 <2.0.0"
-                },
-                "util-extend": {
-                  "version": "1.0.1",
-                  "from": "util-extend@>=1.0.1 <2.0.0"
-                }
-              }
-            },
-            "read-package-json": {
-              "version": "1.3.1",
-              "from": "read-package-json@1.3.1"
-            },
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33 <1.1.0",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                }
-              }
-            },
-            "realize-package-specifier": {
-              "version": "1.3.0",
-              "from": "realize-package-specifier@~1.3.0"
-            },
-            "request": {
-              "version": "2.53.0",
-              "from": "request@>=2.53.0 <2.54.0",
-              "dependencies": {
-                "bl": {
-                  "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0"
-                },
-                "caseless": {
-                  "version": "0.9.0",
-                  "from": "caseless@>=0.9.0 <0.10.0"
-                },
-                "forever-agent": {
-                  "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0"
-                },
-                "form-data": {
-                  "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
-                  "dependencies": {
-                    "async": {
-                      "version": "0.9.0",
-                      "from": "async@>=0.9.0 <0.10.0"
-                    }
-                  }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.0",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0"
-                },
-                "mime-types": {
-                  "version": "2.0.8",
-                  "from": "mime-types@>=2.0.1 <2.1.0",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.6.1",
-                      "from": "mime-db@>=1.6.0 <1.7.0"
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.2",
-                  "from": "node-uuid@>=1.4.0 <1.5.0"
-                },
-                "qs": {
-                  "version": "2.3.3",
-                  "from": "qs@>=2.3.1 <2.4.0"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.0",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0"
-                },
-                "tough-cookie": {
-                  "version": "0.12.1",
-                  "from": "tough-cookie@>=0.12.0",
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.3.2",
-                      "from": "punycode@>=0.2.0"
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11"
-                    },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "ctype@0.5.3"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.6.0",
-                  "from": "oauth-sign@>=0.6.0 <0.7.0"
-                },
-                "hawk": {
-                  "version": "2.3.1",
-                  "from": "hawk@>=2.3.0 <2.4.0",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.11.0",
-                      "from": "hoek@>=2.0.0 <3.0.0"
-                    },
-                    "boom": {
-                      "version": "2.6.1",
-                      "from": "boom@>=2.0.0 <3.0.0"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.4",
-                      "from": "cryptiles@>=2.0.0 <3.0.0"
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0"
-                },
-                "stringstream": {
-                  "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0"
-                },
-                "combined-stream": {
-                  "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.5 <0.1.0",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5"
-                    }
-                  }
-                },
-                "isstream": {
-                  "version": "0.1.1",
-                  "from": "isstream@>=0.1.1 <0.2.0"
-                }
-              }
-            },
-            "retry": {
-              "version": "0.6.1",
-              "from": "retry@>=0.6.1 <0.7.0"
-            },
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "rimraf@latest"
-            },
-            "semver": {
-              "version": "4.3.1",
-              "from": "semver@>=4.3.1 <4.4.0"
-            },
-            "sha": {
-              "version": "1.3.0",
-              "from": "sha@>=1.3.0 <1.4.0",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.0 <1.2.0",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0"
-                    }
-                  }
-                }
-              }
-            },
-            "slide": {
-              "version": "1.1.6",
-              "from": "slide@>=1.1.6 <1.2.0"
-            },
-            "sorted-object": {
-              "version": "1.0.0",
-              "from": "sorted-object@"
-            },
-            "tar": {
-              "version": "1.0.3",
-              "from": "tar@>=1.0.3 <1.1.0"
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "from": "text-table@~0.2.0"
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "from": "uid-number@>=0.0.6 <0.1.0"
-            },
-            "umask": {
-              "version": "1.1.0",
-              "from": "umask@>=1.1.0 <1.2.0"
-            },
-            "which": {
-              "version": "1.0.9",
-              "from": "which@>=1.0.9 <1.1.0"
-            },
-            "wrappy": {
-              "version": "1.0.1",
-              "from": "wrappy@1.0.1"
-            },
-            "write-file-atomic": {
-              "version": "1.1.0",
-              "from": "write-file-atomic@>=1.1.0 <2.0.0"
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.3",
-          "from": "through2@0.6.3",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@1.0.33",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0"
-            }
-          }
-        }
-      }
-    },
-    "gulp-svg-symbols": {
-      "version": "0.3.2",
-      "from": "gulp-svg-symbols@>=0.3.1 <0.4.0",
-      "dependencies": {
-        "bluebird": {
-          "version": "2.10.2",
-          "from": "bluebird@>=2.3.2 <3.0.0"
-        },
-        "consolidate": {
-          "version": "0.13.1",
-          "from": "consolidate@>=0.13.1 <0.14.0"
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0"
-        },
-        "mathjs": {
-          "version": "2.4.1",
-          "from": "mathjs@>=2.3.0 <3.0.0",
-          "dependencies": {
-            "decimal.js": {
-              "version": "4.0.3",
-              "from": "decimal.js@>=4.0.2 <5.0.0"
-            },
-            "fraction.js": {
-              "version": "3.0.0",
-              "from": "fraction.js@>=3.0.0 <4.0.0"
-            },
-            "tiny-emitter": {
-              "version": "1.0.1",
-              "from": "tiny-emitter@>=1.0.0 <2.0.0"
-            },
-            "typed-function": {
-              "version": "0.10.3",
-              "from": "typed-function@>=0.10.3 <0.11.0"
-            }
-          }
-        },
-        "svgo": {
-          "version": "0.5.6",
-          "from": "svgo@>=0.5.6 <0.6.0",
-          "dependencies": {
-            "sax": {
-              "version": "1.1.4",
-              "from": "sax@>=1.1.1 <1.2.0"
-            },
-            "coa": {
-              "version": "1.0.1",
-              "from": "coa@>=1.0.1 <1.1.0",
-              "dependencies": {
-                "q": {
-                  "version": "1.4.1",
-                  "from": "q@>=1.1.2 <2.0.0"
-                }
-              }
-            },
-            "js-yaml": {
-              "version": "3.3.1",
-              "from": "js-yaml@>=3.3.1 <3.4.0",
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.3",
-                  "from": "argparse@>=1.0.2 <1.1.0",
-                  "dependencies": {
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.2.0",
-                  "from": "esprima@>=2.2.0 <2.3.0"
-                }
-              }
-            },
-            "colors": {
-              "version": "1.1.2",
-              "from": "colors@>=1.1.2 <1.2.0"
-            },
-            "whet.extend": {
-              "version": "0.9.9",
-              "from": "whet.extend@>=0.9.9 <0.10.0"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8"
-                }
-              }
-            }
-          }
-        },
-        "through2": {
-          "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.3",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.3",
-                  "from": "process-nextick-args@>=1.0.0 <1.1.0"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0"
-            }
-          }
-        }
-      }
-    },
-    "gulp-symlink": {
-      "version": "2.1.3",
-      "from": "gulp-symlink@>=2.1.0 <3.0.0",
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8"
-            }
-          }
-        },
-        "through2": {
-          "version": "2.0.0",
-          "from": "through2@>=2.0.0 <2.1.0",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.3",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.3",
-                  "from": "process-nextick-args@>=1.0.0 <1.1.0"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0"
-            }
-          }
-        },
-        "async": {
-          "version": "1.4.2",
-          "from": "async@>=1.4.0 <1.5.0"
-        }
-      }
-    },
-    "gulp-tag-version": {
-      "version": "1.3.0",
-      "from": "gulp-tag-version@>=1.2.1 <2.0.0",
-      "dependencies": {
-        "map-stream": {
-          "version": "0.1.0",
-          "from": "map-stream@>=0.1.0 <0.2.0"
-        },
-        "gulp-util": {
-          "version": "2.2.20",
-          "from": "gulp-util@>=2.2.14 <2.3.0",
-          "dependencies": {
-            "chalk": {
-              "version": "0.5.1",
-              "from": "chalk@>=0.5.0 <0.6.0",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0"
-                },
-                "has-ansi": {
-                  "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0"
-                }
-              }
-            },
-            "dateformat": {
-              "version": "1.0.11",
-              "from": "dateformat@>=1.0.7-1.2.3 <2.0.0",
+              "from": "dateformat@>=1.0.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "5.0.0",
-                  "from": "get-stdin@*"
+                  "from": "get-stdin@*",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz"
                 },
                 "meow": {
                   "version": "3.4.2",
                   "from": "meow@*",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
                       "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@>=1.0.1 <2.0.0"
+                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0"
+                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "loud-rejection": {
                       "version": "1.0.0",
-                      "from": "loud-rejection@>=1.0.0 <2.0.0"
-                    },
-                    "minimist": {
-                      "version": "1.2.0",
-                      "from": "minimist@>=1.1.3 <2.0.0"
+                      "from": "loud-rejection@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz"
                     },
                     "normalize-package-data": {
                       "version": "2.3.4",
                       "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.4",
-                          "from": "hosted-git-info@>=2.0.2 <3.0.0"
+                          "from": "hosted-git-info@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
                           "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.0",
-                              "from": "builtin-modules@>=1.0.0 <2.0.0"
+                              "from": "builtin-modules@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
                             }
                           }
                         },
                         "semver": {
                           "version": "5.0.3",
-                          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0"
+                          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
                           "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
                               "from": "spdx-correct@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0"
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.0",
                               "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.3",
-                                  "from": "spdx-exceptions@>=1.0.0 <2.0.0"
+                                  "from": "spdx-exceptions@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz"
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0"
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
                             }
@@ -5560,27 +177,33 @@
                     },
                     "object-assign": {
                       "version": "4.0.1",
-                      "from": "object-assign@>=4.0.1 <5.0.0"
+                      "from": "object-assign@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                     },
                     "read-pkg-up": {
                       "version": "1.0.1",
                       "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "dependencies": {
                         "find-up": {
                           "version": "1.0.0",
                           "from": "find-up@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
                           "dependencies": {
                             "path-exists": {
                               "version": "2.0.0",
-                              "from": "path-exists@>=2.0.0 <3.0.0"
+                              "from": "path-exists@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "1.0.0",
                               "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "1.0.0",
-                                  "from": "pinkie@>=1.0.0 <2.0.0"
+                                  "from": "pinkie@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                 }
                               }
                             }
@@ -5589,46 +212,56 @@
                         "read-pkg": {
                           "version": "1.1.0",
                           "from": "read-pkg@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                           "dependencies": {
                             "load-json-file": {
                               "version": "1.0.1",
                               "from": "load-json-file@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.2",
-                                  "from": "graceful-fs@>=4.1.2 <5.0.0"
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                                 },
                                 "parse-json": {
                                   "version": "2.2.0",
                                   "from": "parse-json@>=2.2.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                   "dependencies": {
                                     "error-ex": {
                                       "version": "1.2.0",
-                                      "from": "error-ex@>=1.2.0 <2.0.0"
+                                      "from": "error-ex@>=1.2.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz"
                                     }
                                   }
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "pify@>=2.0.0 <3.0.0"
+                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "1.0.0",
                                   "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "1.0.0",
-                                      "from": "pinkie@>=1.0.0 <2.0.0"
+                                      "from": "pinkie@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-bom": {
                                   "version": "2.0.0",
                                   "from": "strip-bom@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                   "dependencies": {
                                     "is-utf8": {
                                       "version": "0.2.0",
-                                      "from": "is-utf8@>=0.2.0 <0.3.0"
+                                      "from": "is-utf8@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                                     }
                                   }
                                 }
@@ -5637,22 +270,27 @@
                             "path-type": {
                               "version": "1.0.0",
                               "from": "path-type@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.2",
-                                  "from": "graceful-fs@>=4.1.2 <5.0.0"
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "pify@>=2.0.0 <3.0.0"
+                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "1.0.0",
                                   "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "1.0.0",
-                                      "from": "pinkie@>=1.0.0 <2.0.0"
+                                      "from": "pinkie@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                     }
                                   }
                                 }
@@ -5665,22 +303,27 @@
                     "redent": {
                       "version": "1.0.0",
                       "from": "redent@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                       "dependencies": {
                         "indent-string": {
                           "version": "2.1.0",
                           "from": "indent-string@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "dependencies": {
                             "repeating": {
                               "version": "2.0.0",
                               "from": "repeating@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
                                   "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0"
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                     }
                                   }
                                 }
@@ -5691,10 +334,12 @@
                         "strip-indent": {
                           "version": "1.0.1",
                           "from": "strip-indent@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                           "dependencies": {
                             "get-stdin": {
                               "version": "4.0.1",
-                              "from": "get-stdin@>=4.0.1 <5.0.0"
+                              "from": "get-stdin@>=4.0.1 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                             }
                           }
                         }
@@ -5702,131 +347,167 @@
                     },
                     "trim-newlines": {
                       "version": "1.0.0",
-                      "from": "trim-newlines@>=1.0.0 <2.0.0"
+                      "from": "trim-newlines@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                     }
                   }
                 }
               }
             },
+            "fancy-log": {
+              "version": "1.1.0",
+              "from": "fancy-log@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz"
+            },
+            "gulplog": {
+              "version": "1.0.0",
+              "from": "gulplog@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+              "dependencies": {
+                "glogg": {
+                  "version": "1.0.0",
+                  "from": "glogg@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+                  "dependencies": {
+                    "sparkles": {
+                      "version": "1.0.0",
+                      "from": "sparkles@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "has-gulplog": {
+              "version": "0.1.0",
+              "from": "has-gulplog@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+              "dependencies": {
+                "sparkles": {
+                  "version": "1.0.0",
+                  "from": "sparkles@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
             "lodash._reinterpolate": {
-              "version": "2.4.1",
-              "from": "lodash._reinterpolate@>=2.4.1 <3.0.0"
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
             },
             "lodash.template": {
-              "version": "2.4.1",
-              "from": "lodash.template@>=2.4.1 <3.0.0",
+              "version": "3.6.2",
+              "from": "lodash.template@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
               "dependencies": {
-                "lodash.defaults": {
-                  "version": "2.4.1",
-                  "from": "lodash.defaults@>=2.4.1 <2.5.0",
-                  "dependencies": {
-                    "lodash._objecttypes": {
-                      "version": "2.4.1",
-                      "from": "lodash._objecttypes@>=2.4.1 <2.5.0"
-                    }
-                  }
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                 },
                 "lodash.escape": {
-                  "version": "2.4.1",
-                  "from": "lodash.escape@>=2.4.1 <2.5.0",
-                  "dependencies": {
-                    "lodash._escapehtmlchar": {
-                      "version": "2.4.1",
-                      "from": "lodash._escapehtmlchar@>=2.4.1 <2.5.0",
-                      "dependencies": {
-                        "lodash._htmlescapes": {
-                          "version": "2.4.1",
-                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0"
-                        }
-                      }
-                    },
-                    "lodash._reunescapedhtml": {
-                      "version": "2.4.1",
-                      "from": "lodash._reunescapedhtml@>=2.4.1 <2.5.0",
-                      "dependencies": {
-                        "lodash._htmlescapes": {
-                          "version": "2.4.1",
-                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash._escapestringchar": {
-                  "version": "2.4.1",
-                  "from": "lodash._escapestringchar@>=2.4.1 <2.5.0"
+                  "version": "3.0.0",
+                  "from": "lodash.escape@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
                 },
                 "lodash.keys": {
-                  "version": "2.4.1",
-                  "from": "lodash.keys@>=2.4.1 <2.5.0",
+                  "version": "3.1.2",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1",
-                      "from": "lodash._isnative@>=2.4.1 <2.5.0"
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
-                    "lodash.isobject": {
-                      "version": "2.4.1",
-                      "from": "lodash.isobject@>=2.4.1 <2.5.0",
-                      "dependencies": {
-                        "lodash._objecttypes": {
-                          "version": "2.4.1",
-                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0"
-                        }
-                      }
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                     },
-                    "lodash._shimkeys": {
-                      "version": "2.4.1",
-                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
-                      "dependencies": {
-                        "lodash._objecttypes": {
-                          "version": "2.4.1",
-                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0"
-                        }
-                      }
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
                 },
-                "lodash.templatesettings": {
-                  "version": "2.4.1",
-                  "from": "lodash.templatesettings@>=2.4.1 <2.5.0"
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                 },
-                "lodash.values": {
-                  "version": "2.4.1",
-                  "from": "lodash.values@>=2.4.1 <2.5.0"
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
                 }
               }
             },
             "minimist": {
-              "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0"
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "multipipe": {
               "version": "0.1.2",
-              "from": "multipipe@>=0.1.0 <0.2.0",
+              "from": "multipipe@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
               "dependencies": {
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
                       "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0"
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1"
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0"
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -5834,231 +515,403 @@
                 }
               }
             },
-            "through2": {
-              "version": "0.5.1",
-              "from": "through2@>=0.5.0 <0.6.0",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "3.0.0",
-                  "from": "xtend@>=3.0.0 <3.1.0"
-                }
-              }
+            "object-assign": {
+              "version": "3.0.0",
+              "from": "object-assign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
-              "version": "0.2.3",
-              "from": "vinyl@>=0.2.1 <0.3.0",
+              "version": "0.5.3",
+              "from": "vinyl@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
               "dependencies": {
+                "clone": {
+                  "version": "1.0.2",
+                  "from": "clone@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                },
                 "clone-stats": {
                   "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.1.0"
+                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                 }
               }
             }
           }
         },
-        "gulp-git": {
-          "version": "0.3.6",
-          "from": "gulp-git@>=0.3.6 <0.4.0",
+        "node-sass": {
+          "version": "3.3.3",
+          "from": "https://registry.npmjs.org/node-sass/-/node-sass-3.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.3.3.tgz",
           "dependencies": {
-            "any-shell-escape": {
-              "version": "0.1.1",
-              "from": "any-shell-escape@>=0.1.1 <0.2.0"
+            "async-foreach": {
+              "version": "0.1.3",
+              "from": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
             },
-            "through2": {
-              "version": "0.4.2",
-              "from": "through2@>=0.4.1 <0.5.0",
+            "chalk": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@1.0.33",
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0"
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
-                "xtend": {
-                  "version": "2.1.2",
-                  "from": "xtend@>=2.1.1 <2.2.0",
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
-                    "object-keys": {
-                      "version": "0.4.0",
-                      "from": "object-keys@>=0.4.0 <0.5.0"
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "cross-spawn": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.0.0.tgz",
+              "dependencies": {
+                "cross-spawn-async": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.0.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                    },
+                    "which": {
+                      "version": "1.2.0",
+                      "from": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+                      "dependencies": {
+                        "is-absolute": {
+                          "version": "0.1.7",
+                          "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                          "dependencies": {
+                            "is-relative": {
+                              "version": "0.1.3",
+                              "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "spawn-sync": {
+                  "version": "1.0.13",
+                  "from": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz",
+                  "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.5.1",
+                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "2.0.3",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.3",
+                              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "os-shim": {
+                      "version": "0.1.3",
+                      "from": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
                     }
                   }
                 }
               }
-            }
-          }
-        }
-      }
-    },
-    "gulp-util": {
-      "version": "3.0.7",
-      "from": "gulp-util@>=3.0.0 <4.0.0",
-      "dependencies": {
-        "array-differ": {
-          "version": "1.0.0",
-          "from": "array-differ@>=1.0.0 <2.0.0"
-        },
-        "array-uniq": {
-          "version": "1.0.2",
-          "from": "array-uniq@>=1.0.2 <2.0.0"
-        },
-        "beeper": {
-          "version": "1.1.0",
-          "from": "beeper@>=1.0.0 <2.0.0"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0"
             },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+            "gaze": {
+              "version": "0.5.2",
+              "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
               "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0"
+                "globule": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                    },
+                    "glob": {
+                      "version": "3.1.21",
+                      "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "1.2.3",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                        },
+                        "inherits": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.7.0",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0"
-            }
-          }
-        },
-        "dateformat": {
-          "version": "1.0.11",
-          "from": "dateformat@>=1.0.11 <2.0.0",
-          "dependencies": {
             "get-stdin": {
-              "version": "5.0.0",
-              "from": "get-stdin@*"
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
             },
             "meow": {
               "version": "3.4.2",
-              "from": "meow@*",
+              "from": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.1 <2.0.0"
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0"
+                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "loud-rejection": {
                   "version": "1.0.0",
-                  "from": "loud-rejection@>=1.0.0 <2.0.0"
+                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz"
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.4",
-                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
-                      "from": "hosted-git-info@>=2.0.2 <3.0.0"
+                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.0",
-                          "from": "builtin-modules@>=1.0.0 <2.0.0"
+                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.0.3",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0"
+                      "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0"
+                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.0",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.3",
-                              "from": "spdx-exceptions@>=1.0.0 <2.0.0"
+                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz"
                             },
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0"
+                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
                         }
@@ -6066,29 +919,30 @@
                     }
                   }
                 },
-                "object-assign": {
-                  "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0"
-                },
                 "read-pkg-up": {
                   "version": "1.0.1",
-                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
                       "version": "1.0.0",
-                      "from": "find-up@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.0.0",
-                          "from": "path-exists@>=2.0.0 <3.0.0"
+                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "1.0.0",
-                          "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "1.0.0",
-                              "from": "pinkie@>=1.0.0 <2.0.0"
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                             }
                           }
                         }
@@ -6096,47 +950,57 @@
                     },
                     "read-pkg": {
                       "version": "1.1.0",
-                      "from": "read-pkg@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.0.1",
-                          "from": "load-json-file@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0"
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
-                              "from": "parse-json@>=2.2.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.2.0",
-                                  "from": "error-ex@>=1.2.0 <2.0.0"
+                                  "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz"
                                 }
                               }
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0"
+                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "1.0.0",
-                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "1.0.0",
-                                  "from": "pinkie@>=1.0.0 <2.0.0"
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
-                              "from": "strip-bom@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.0",
-                                  "from": "is-utf8@>=0.2.0 <0.3.0"
+                                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                                 }
                               }
                             }
@@ -6144,23 +1008,28 @@
                         },
                         "path-type": {
                           "version": "1.0.0",
-                          "from": "path-type@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0"
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0"
+                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "1.0.0",
-                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "1.0.0",
-                                  "from": "pinkie@>=1.0.0 <2.0.0"
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                 }
                               }
                             }
@@ -6172,23 +1041,28 @@
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "redent@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
-                      "from": "indent-string@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.0",
-                          "from": "repeating@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0"
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
                             }
@@ -6198,149 +1072,888 @@
                     },
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "strip-indent@>=1.0.1 <2.0.0",
-                      "dependencies": {
-                        "get-stdin": {
-                          "version": "4.0.1",
-                          "from": "get-stdin@>=4.0.1 <5.0.0"
-                        }
-                      }
+                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "trim-newlines@>=1.0.0 <2.0.0"
-                }
-              }
-            }
-          }
-        },
-        "fancy-log": {
-          "version": "1.1.0",
-          "from": "fancy-log@>=1.1.0 <2.0.0"
-        },
-        "gulplog": {
-          "version": "1.0.0",
-          "from": "gulplog@>=1.0.0 <2.0.0",
-          "dependencies": {
-            "glogg": {
-              "version": "1.0.0",
-              "from": "glogg@>=1.0.0 <2.0.0",
-              "dependencies": {
-                "sparkles": {
-                  "version": "1.0.0",
-                  "from": "sparkles@>=1.0.0 <2.0.0"
-                }
-              }
-            }
-          }
-        },
-        "has-gulplog": {
-          "version": "0.1.0",
-          "from": "has-gulplog@>=0.1.0 <0.2.0",
-          "dependencies": {
-            "sparkles": {
-              "version": "1.0.0",
-              "from": "sparkles@>=1.0.0 <2.0.0"
-            }
-          }
-        },
-        "lodash._reescape": {
-          "version": "3.0.0",
-          "from": "lodash._reescape@>=3.0.0 <4.0.0"
-        },
-        "lodash._reevaluate": {
-          "version": "3.0.0",
-          "from": "lodash._reevaluate@>=3.0.0 <4.0.0"
-        },
-        "lodash._reinterpolate": {
-          "version": "3.0.0",
-          "from": "lodash._reinterpolate@>=3.0.0 <4.0.0"
-        },
-        "lodash.template": {
-          "version": "3.6.2",
-          "from": "lodash.template@>=3.0.0 <4.0.0",
-          "dependencies": {
-            "lodash._basecopy": {
-              "version": "3.0.1",
-              "from": "lodash._basecopy@>=3.0.0 <4.0.0"
-            },
-            "lodash._basetostring": {
-              "version": "3.0.1",
-              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
-            },
-            "lodash._basevalues": {
-              "version": "3.0.0",
-              "from": "lodash._basevalues@>=3.0.0 <4.0.0"
-            },
-            "lodash._isiterateecall": {
-              "version": "3.0.9",
-              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0"
-            },
-            "lodash.escape": {
-              "version": "3.0.0",
-              "from": "lodash.escape@>=3.0.0 <4.0.0"
-            },
-            "lodash.keys": {
-              "version": "3.1.2",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0"
+                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
             },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0"
-            },
-            "lodash.templatesettings": {
-              "version": "3.1.0",
-              "from": "lodash.templatesettings@>=3.0.0 <4.0.0"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0"
-        },
-        "multipipe": {
-          "version": "0.1.2",
-          "from": "multipipe@>=0.1.2 <0.2.0",
-          "dependencies": {
-            "duplexer2": {
-              "version": "0.0.2",
-              "from": "duplexer2@0.0.2",
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "nan": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+            },
+            "npmconf": {
+              "version": "2.1.2",
+              "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.9",
+                  "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
                   "dependencies": {
-                    "core-util-is": {
+                    "proto-list": {
+                      "version": "1.2.4",
+                      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                },
+                "nopt": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "4.3.6",
+                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                }
+              }
+            },
+            "node-gyp": {
+              "version": "3.0.3",
+              "from": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.0.3.tgz",
+              "dependencies": {
+                "fstream": {
+                  "version": "1.0.8",
+                  "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0"
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.1",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.1",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.2",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+                  "dependencies": {
+                    "ansi": {
+                      "version": "0.3.0",
+                      "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                      "dependencies": {
+                        "delegates": {
+                          "version": "0.1.0",
+                          "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "gauge": {
+                      "version": "1.2.2",
+                      "from": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+                      "dependencies": {
+                        "has-unicode": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                        },
+                        "lodash.pad": {
+                          "version": "3.1.1",
+                          "from": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padleft": {
+                          "version": "3.1.1",
+                          "from": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padright": {
+                          "version": "3.1.1",
+                          "from": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    }
+                  }
+                },
+                "path-array": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-array/-/path-array-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.0.tgz",
+                  "dependencies": {
+                    "array-index": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/array-index/-/array-index-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/array-index/-/array-index-0.1.1.tgz",
+                      "dependencies": {
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.4.3",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.1",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.1",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "5.0.3",
+                  "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+                },
+                "tar": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.8",
+                      "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "which": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+                  "dependencies": {
+                    "is-absolute": {
+                      "version": "0.1.7",
+                      "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                      "dependencies": {
+                        "is-relative": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "request": {
+              "version": "2.65.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.3",
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "1.5.0",
+                      "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.7",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.19.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "5.2.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.11.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                },
+                "hawk": {
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "boom": {
+                      "version": "2.10.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-2.10.0.tgz",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.0.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "har-validator": {
+                  "version": "2.0.2",
+                  "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.2",
+                      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sass-graph": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "yargs": {
+                  "version": "3.29.0",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "cliui": {
+                      "version": "3.0.3",
+                      "from": "https://registry.npmjs.org/cliui/-/cliui-3.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.0.3.tgz",
+                      "dependencies": {
+                        "string-width": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "wrap-ansi": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                    },
+                    "os-locale": {
+                      "version": "1.4.0",
+                      "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                      "dependencies": {
+                        "lcid": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                          "dependencies": {
+                            "invert-kv": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "window-size": {
+                      "version": "0.1.2",
+                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
+                    },
+                    "y18n": {
+                      "version": "3.2.0",
+                      "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
                     }
                   }
                 }
@@ -6349,64 +1962,68 @@
           }
         },
         "object-assign": {
-          "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0"
-        },
-        "replace-ext": {
-          "version": "0.0.1",
-          "from": "replace-ext@0.0.1"
+          "version": "4.0.1",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.3",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1"
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.3",
-                  "from": "process-nextick-args@>=1.0.0 <1.1.0"
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0"
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0"
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
-        "vinyl": {
-          "version": "0.5.3",
-          "from": "vinyl@>=0.5.0 <0.6.0",
+        "vinyl-sourcemaps-apply": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
           "dependencies": {
-            "clone": {
-              "version": "1.0.2",
-              "from": "clone@>=1.0.0 <2.0.0"
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2"
+            "source-map": {
+              "version": "0.5.3",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             }
           }
         }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,6416 @@
+{
+  "name": "optimizely-oui",
+  "version": "6.0.0",
+  "dependencies": {
+    "browser-sync": {
+      "version": "2.9.11",
+      "from": "browser-sync@>=2.9.8 <3.0.0",
+      "dependencies": {
+        "anymatch": {
+          "version": "1.3.0",
+          "from": "anymatch@>=1.3.0 <2.0.0",
+          "dependencies": {
+            "arrify": {
+              "version": "1.0.0",
+              "from": "arrify@>=1.0.0 <2.0.0"
+            },
+            "micromatch": {
+              "version": "2.2.0",
+              "from": "micromatch@>=2.1.5 <3.0.0",
+              "dependencies": {
+                "arr-diff": {
+                  "version": "1.1.0",
+                  "from": "arr-diff@>=1.0.1 <2.0.0",
+                  "dependencies": {
+                    "arr-flatten": {
+                      "version": "1.0.1",
+                      "from": "arr-flatten@>=1.0.1 <2.0.0"
+                    },
+                    "array-slice": {
+                      "version": "0.2.3",
+                      "from": "array-slice@>=0.2.3 <0.3.0"
+                    }
+                  }
+                },
+                "array-unique": {
+                  "version": "0.2.1",
+                  "from": "array-unique@>=0.2.1 <0.3.0"
+                },
+                "braces": {
+                  "version": "1.8.2",
+                  "from": "braces@>=1.8.0 <2.0.0",
+                  "dependencies": {
+                    "expand-range": {
+                      "version": "1.8.1",
+                      "from": "expand-range@>=1.8.1 <2.0.0",
+                      "dependencies": {
+                        "fill-range": {
+                          "version": "2.2.2",
+                          "from": "fill-range@>=2.1.0 <3.0.0",
+                          "dependencies": {
+                            "is-number": {
+                              "version": "1.1.2",
+                              "from": "is-number@>=1.1.2 <2.0.0"
+                            },
+                            "isobject": {
+                              "version": "1.0.2",
+                              "from": "isobject@>=1.0.0 <2.0.0"
+                            },
+                            "randomatic": {
+                              "version": "1.1.0",
+                              "from": "randomatic@>=1.1.0 <2.0.0"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "repeat-string@>=1.5.2 <2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lazy-cache": {
+                      "version": "0.2.4",
+                      "from": "lazy-cache@>=0.2.3 <0.3.0"
+                    },
+                    "preserve": {
+                      "version": "0.2.0",
+                      "from": "preserve@>=0.2.0 <0.3.0"
+                    },
+                    "repeat-element": {
+                      "version": "1.1.2",
+                      "from": "repeat-element@>=1.1.2 <2.0.0"
+                    }
+                  }
+                },
+                "expand-brackets": {
+                  "version": "0.1.4",
+                  "from": "expand-brackets@>=0.1.1 <0.2.0"
+                },
+                "extglob": {
+                  "version": "0.3.1",
+                  "from": "extglob@>=0.3.0 <0.4.0",
+                  "dependencies": {
+                    "ansi-green": {
+                      "version": "0.1.1",
+                      "from": "ansi-green@>=0.1.1 <0.2.0",
+                      "dependencies": {
+                        "ansi-wrap": {
+                          "version": "0.1.0",
+                          "from": "ansi-wrap@0.1.0"
+                        }
+                      }
+                    },
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "is-extglob@>=1.0.0 <2.0.0"
+                    },
+                    "success-symbol": {
+                      "version": "0.1.0",
+                      "from": "success-symbol@>=0.1.0 <0.2.0"
+                    }
+                  }
+                },
+                "filename-regex": {
+                  "version": "2.0.0",
+                  "from": "filename-regex@>=2.0.0 <3.0.0"
+                },
+                "is-glob": {
+                  "version": "1.1.3",
+                  "from": "is-glob@>=1.1.3 <2.0.0"
+                },
+                "kind-of": {
+                  "version": "1.1.0",
+                  "from": "kind-of@>=1.1.0 <2.0.0"
+                },
+                "object.omit": {
+                  "version": "1.1.0",
+                  "from": "object.omit@>=1.1.0 <2.0.0",
+                  "dependencies": {
+                    "for-own": {
+                      "version": "0.1.3",
+                      "from": "for-own@>=0.1.3 <0.2.0",
+                      "dependencies": {
+                        "for-in": {
+                          "version": "0.1.4",
+                          "from": "for-in@>=0.1.4 <0.2.0"
+                        }
+                      }
+                    },
+                    "isobject": {
+                      "version": "1.0.2",
+                      "from": "isobject@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "parse-glob": {
+                  "version": "3.0.4",
+                  "from": "parse-glob@>=3.0.1 <4.0.0",
+                  "dependencies": {
+                    "glob-base": {
+                      "version": "0.3.0",
+                      "from": "glob-base@>=0.3.0 <0.4.0",
+                      "dependencies": {
+                        "glob-parent": {
+                          "version": "2.0.0",
+                          "from": "glob-parent@>=2.0.0 <3.0.0"
+                        }
+                      }
+                    },
+                    "is-dotfile": {
+                      "version": "1.0.2",
+                      "from": "is-dotfile@>=1.0.0 <2.0.0"
+                    },
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "is-extglob@>=1.0.0 <2.0.0"
+                    },
+                    "is-glob": {
+                      "version": "2.0.1",
+                      "from": "is-glob@>=2.0.0 <3.0.0"
+                    }
+                  }
+                },
+                "regex-cache": {
+                  "version": "0.4.2",
+                  "from": "regex-cache@>=0.4.2 <0.5.0",
+                  "dependencies": {
+                    "is-equal-shallow": {
+                      "version": "0.1.3",
+                      "from": "is-equal-shallow@>=0.1.1 <0.2.0"
+                    },
+                    "is-primitive": {
+                      "version": "2.0.0",
+                      "from": "is-primitive@>=2.0.0 <3.0.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "async-each-series": {
+          "version": "0.1.1",
+          "from": "async-each-series@>=0.1.1 <0.2.0"
+        },
+        "browser-sync-client": {
+          "version": "2.3.4",
+          "from": "browser-sync-client@>=2.3.3 <3.0.0",
+          "dependencies": {
+            "etag": {
+              "version": "1.7.0",
+              "from": "etag@>=1.7.0 <2.0.0"
+            },
+            "fresh": {
+              "version": "0.3.0",
+              "from": "fresh@>=0.3.0 <0.4.0"
+            }
+          }
+        },
+        "browser-sync-ui": {
+          "version": "0.5.16",
+          "from": "browser-sync-ui@>=0.5.16 <0.6.0",
+          "dependencies": {
+            "connect-history-api-fallback": {
+              "version": "0.0.5",
+              "from": "connect-history-api-fallback@0.0.5"
+            },
+            "stream-throttle": {
+              "version": "0.1.3",
+              "from": "stream-throttle@>=0.1.3 <0.2.0",
+              "dependencies": {
+                "commander": {
+                  "version": "2.9.0",
+                  "from": "commander@>=2.2.0 <3.0.0",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>=1.0.0"
+                    }
+                  }
+                },
+                "limiter": {
+                  "version": "1.1.0",
+                  "from": "limiter@>=1.0.5 <2.0.0"
+                }
+              }
+            },
+            "weinre": {
+              "version": "2.0.0-pre-I0Z7U9OV",
+              "from": "weinre@>=2.0.0-pre-I0Z7U9OV <3.0.0",
+              "dependencies": {
+                "express": {
+                  "version": "2.5.11",
+                  "from": "express@>=2.5.0 <2.6.0",
+                  "dependencies": {
+                    "connect": {
+                      "version": "1.9.2",
+                      "from": "connect@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "formidable": {
+                          "version": "1.0.17",
+                          "from": "formidable@>=1.0.0 <1.1.0"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.4",
+                      "from": "mime@1.2.4"
+                    },
+                    "qs": {
+                      "version": "0.4.2",
+                      "from": "qs@>=0.4.0 <0.5.0"
+                    },
+                    "mkdirp": {
+                      "version": "0.3.0",
+                      "from": "mkdirp@0.3.0"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.4",
+                  "from": "nopt@>=3.0.0 <3.1.0",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0"
+                }
+              }
+            }
+          }
+        },
+        "chokidar": {
+          "version": "1.2.0",
+          "from": "chokidar@>=1.0.5 <2.0.0",
+          "dependencies": {
+            "arrify": {
+              "version": "1.0.0",
+              "from": "arrify@>=1.0.0 <2.0.0"
+            },
+            "async-each": {
+              "version": "0.1.6",
+              "from": "async-each@>=0.1.5 <0.2.0"
+            },
+            "glob-parent": {
+              "version": "2.0.0",
+              "from": "glob-parent@>=2.0.0 <3.0.0"
+            },
+            "is-binary-path": {
+              "version": "1.0.1",
+              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.3.1",
+                  "from": "binary-extensions@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "from": "is-glob@>=2.0.0 <3.0.0",
+              "dependencies": {
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "from": "is-extglob@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "lodash.flatten": {
+              "version": "3.0.2",
+              "from": "lodash.flatten@>=3.0.2 <4.0.0",
+              "dependencies": {
+                "lodash._baseflatten": {
+                  "version": "3.1.4",
+                  "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0"
+                    }
+                  }
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0"
+            },
+            "readdirp": {
+              "version": "2.0.0",
+              "from": "readdirp@>=2.0.0 <3.0.0",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.2",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.10 <3.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "from": "balanced-match@>=0.2.0 <0.3.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.0.3",
+                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.3",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "fsevents": {
+              "version": "1.0.2",
+              "from": "fsevents@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "nan": {
+                  "version": "2.1.0",
+                  "from": "nan@>=2.0.2 <3.0.0"
+                },
+                "node-pre-gyp": {
+                  "version": "0.6.12",
+                  "from": "node-pre-gyp@0.6.12",
+                  "dependencies": {
+                    "nopt": {
+                      "version": "3.0.4",
+                      "from": "nopt@~3.0.1",
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.7",
+                          "from": "abbrev@1"
+                        }
+                      }
+                    },
+                    "npmlog": {
+                      "version": "1.2.1",
+                      "from": "npmlog@~1.2.0",
+                      "dependencies": {
+                        "ansi": {
+                          "version": "0.3.0",
+                          "from": "ansi@~0.3.0"
+                        },
+                        "are-we-there-yet": {
+                          "version": "1.0.4",
+                          "from": "are-we-there-yet@~1.0.0",
+                          "dependencies": {
+                            "delegates": {
+                              "version": "0.1.0",
+                              "from": "delegates@^0.1.0"
+                            },
+                            "readable-stream": {
+                              "version": "1.1.13",
+                              "from": "readable-stream@^1.1.13",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@~1.0.0"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@~0.10.x"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "gauge": {
+                          "version": "1.2.2",
+                          "from": "gauge@~1.2.0",
+                          "dependencies": {
+                            "has-unicode": {
+                              "version": "1.0.0",
+                              "from": "has-unicode@^1.0.0"
+                            },
+                            "lodash.pad": {
+                              "version": "3.1.1",
+                              "from": "lodash.pad@^3.0.0",
+                              "dependencies": {
+                                "lodash._basetostring": {
+                                  "version": "3.0.1",
+                                  "from": "lodash._basetostring@^3.0.0"
+                                },
+                                "lodash._createpadding": {
+                                  "version": "3.6.1",
+                                  "from": "lodash._createpadding@^3.0.0",
+                                  "dependencies": {
+                                    "lodash.repeat": {
+                                      "version": "3.0.1",
+                                      "from": "lodash.repeat@^3.0.0"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash.padleft": {
+                              "version": "3.1.1",
+                              "from": "lodash.padleft@^3.0.0",
+                              "dependencies": {
+                                "lodash._basetostring": {
+                                  "version": "3.0.1",
+                                  "from": "lodash._basetostring@^3.0.0"
+                                },
+                                "lodash._createpadding": {
+                                  "version": "3.6.1",
+                                  "from": "lodash._createpadding@^3.0.0",
+                                  "dependencies": {
+                                    "lodash.repeat": {
+                                      "version": "3.0.1",
+                                      "from": "lodash.repeat@^3.0.0"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash.padright": {
+                              "version": "3.1.1",
+                              "from": "lodash.padright@^3.0.0",
+                              "dependencies": {
+                                "lodash._basetostring": {
+                                  "version": "3.0.1",
+                                  "from": "lodash._basetostring@^3.0.0"
+                                },
+                                "lodash._createpadding": {
+                                  "version": "3.6.1",
+                                  "from": "lodash._createpadding@^3.0.0",
+                                  "dependencies": {
+                                    "lodash.repeat": {
+                                      "version": "3.0.1",
+                                      "from": "lodash.repeat@^3.0.0"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "request": {
+                      "version": "2.64.0",
+                      "from": "request@2.x",
+                      "dependencies": {
+                        "bl": {
+                          "version": "1.0.0",
+                          "from": "bl@~1.0.0",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "2.0.2",
+                              "from": "readable-stream@~2.0.0",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@~1.0.0"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.1"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1"
+                                },
+                                "process-nextick-args": {
+                                  "version": "1.0.3",
+                                  "from": "process-nextick-args@~1.0.0"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@~0.10.x"
+                                },
+                                "util-deprecate": {
+                                  "version": "1.0.1",
+                                  "from": "util-deprecate@~1.0.1"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "caseless": {
+                          "version": "0.11.0",
+                          "from": "caseless@~0.11.0"
+                        },
+                        "extend": {
+                          "version": "3.0.0",
+                          "from": "extend@~3.0.0"
+                        },
+                        "forever-agent": {
+                          "version": "0.6.1",
+                          "from": "forever-agent@~0.6.0"
+                        },
+                        "form-data": {
+                          "version": "1.0.0-rc3",
+                          "from": "form-data@~1.0.0-rc1",
+                          "dependencies": {
+                            "async": {
+                              "version": "1.4.2",
+                              "from": "async@^1.4.0"
+                            }
+                          }
+                        },
+                        "json-stringify-safe": {
+                          "version": "5.0.1",
+                          "from": "json-stringify-safe@~5.0.0"
+                        },
+                        "mime-types": {
+                          "version": "2.1.7",
+                          "from": "mime-types@~2.1.2",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.19.0",
+                              "from": "mime-db@~1.19.0"
+                            }
+                          }
+                        },
+                        "node-uuid": {
+                          "version": "1.4.3",
+                          "from": "node-uuid@~1.4.0"
+                        },
+                        "qs": {
+                          "version": "5.1.0",
+                          "from": "qs@~5.1.0"
+                        },
+                        "tunnel-agent": {
+                          "version": "0.4.1",
+                          "from": "tunnel-agent@~0.4.0"
+                        },
+                        "tough-cookie": {
+                          "version": "2.1.0",
+                          "from": "tough-cookie@>=0.12.0"
+                        },
+                        "http-signature": {
+                          "version": "0.11.0",
+                          "from": "http-signature@~0.11.0",
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "0.1.5",
+                              "from": "assert-plus@^0.1.5"
+                            },
+                            "asn1": {
+                              "version": "0.1.11",
+                              "from": "asn1@0.1.11"
+                            },
+                            "ctype": {
+                              "version": "0.5.3",
+                              "from": "ctype@0.5.3"
+                            }
+                          }
+                        },
+                        "oauth-sign": {
+                          "version": "0.8.0",
+                          "from": "oauth-sign@~0.8.0"
+                        },
+                        "hawk": {
+                          "version": "3.1.0",
+                          "from": "hawk@~3.1.0",
+                          "dependencies": {
+                            "hoek": {
+                              "version": "2.16.3",
+                              "from": "hoek@2.x.x"
+                            },
+                            "boom": {
+                              "version": "2.9.0",
+                              "from": "boom@^2.8.x"
+                            },
+                            "cryptiles": {
+                              "version": "2.0.5",
+                              "from": "cryptiles@2.x.x"
+                            },
+                            "sntp": {
+                              "version": "1.0.9",
+                              "from": "sntp@1.x.x"
+                            }
+                          }
+                        },
+                        "aws-sign2": {
+                          "version": "0.5.0",
+                          "from": "aws-sign2@~0.5.0"
+                        },
+                        "stringstream": {
+                          "version": "0.0.4",
+                          "from": "stringstream@~0.0.4"
+                        },
+                        "combined-stream": {
+                          "version": "1.0.5",
+                          "from": "combined-stream@~1.0.1",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "1.0.0",
+                              "from": "delayed-stream@~1.0.0"
+                            }
+                          }
+                        },
+                        "isstream": {
+                          "version": "0.1.2",
+                          "from": "isstream@~0.1.1"
+                        },
+                        "har-validator": {
+                          "version": "1.8.0",
+                          "from": "har-validator@^1.6.1",
+                          "dependencies": {
+                            "bluebird": {
+                              "version": "2.10.2",
+                              "from": "bluebird@^2.9.30"
+                            },
+                            "chalk": {
+                              "version": "1.1.1",
+                              "from": "chalk@^1.0.0",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.1.0",
+                                  "from": "ansi-styles@^2.1.0"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "from": "escape-string-regexp@^1.0.2"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@^2.0.0",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@^2.0.0"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.0",
+                                  "from": "strip-ansi@^3.0.0",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@^2.0.0"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@^2.0.0"
+                                }
+                              }
+                            },
+                            "commander": {
+                              "version": "2.8.1",
+                              "from": "commander@^2.8.1",
+                              "dependencies": {
+                                "graceful-readlink": {
+                                  "version": "1.0.1",
+                                  "from": "graceful-readlink@>= 1.0.0"
+                                }
+                              }
+                            },
+                            "is-my-json-valid": {
+                              "version": "2.12.2",
+                              "from": "is-my-json-valid@^2.12.0",
+                              "dependencies": {
+                                "generate-function": {
+                                  "version": "2.0.0",
+                                  "from": "generate-function@^2.0.0"
+                                },
+                                "generate-object-property": {
+                                  "version": "1.2.0",
+                                  "from": "generate-object-property@^1.1.0",
+                                  "dependencies": {
+                                    "is-property": {
+                                      "version": "1.0.2",
+                                      "from": "is-property@^1.0.0"
+                                    }
+                                  }
+                                },
+                                "jsonpointer": {
+                                  "version": "2.0.0",
+                                  "from": "jsonpointer@2.0.0"
+                                },
+                                "xtend": {
+                                  "version": "4.0.0",
+                                  "from": "xtend@^4.0.0"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "5.0.3",
+                      "from": "semver@~5.0.1"
+                    },
+                    "tar": {
+                      "version": "2.2.1",
+                      "from": "tar@~2.2.0",
+                      "dependencies": {
+                        "block-stream": {
+                          "version": "0.0.8",
+                          "from": "block-stream@*"
+                        },
+                        "fstream": {
+                          "version": "1.0.8",
+                          "from": "fstream@^1.0.2",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.2",
+                              "from": "graceful-fs@^4.1.2"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2"
+                        }
+                      }
+                    },
+                    "tar-pack": {
+                      "version": "2.0.0",
+                      "from": "tar-pack@~2.0.0",
+                      "dependencies": {
+                        "uid-number": {
+                          "version": "0.0.3",
+                          "from": "uid-number@0.0.3"
+                        },
+                        "once": {
+                          "version": "1.1.1",
+                          "from": "once@~1.1.1"
+                        },
+                        "debug": {
+                          "version": "0.7.4",
+                          "from": "debug@~0.7.2"
+                        },
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "rimraf@~2.2.0"
+                        },
+                        "fstream": {
+                          "version": "0.1.31",
+                          "from": "fstream@~0.1.22",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "3.0.8",
+                              "from": "graceful-fs@~3.0.2"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.0"
+                            }
+                          }
+                        },
+                        "tar": {
+                          "version": "0.1.20",
+                          "from": "tar@~0.1.17",
+                          "dependencies": {
+                            "block-stream": {
+                              "version": "0.0.8",
+                              "from": "block-stream@*"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2"
+                            }
+                          }
+                        },
+                        "fstream-ignore": {
+                          "version": "0.0.7",
+                          "from": "fstream-ignore@0.0.7",
+                          "dependencies": {
+                            "minimatch": {
+                              "version": "0.2.14",
+                              "from": "minimatch@~0.2.0",
+                              "dependencies": {
+                                "lru-cache": {
+                                  "version": "2.7.0",
+                                  "from": "lru-cache@2"
+                                },
+                                "sigmund": {
+                                  "version": "1.0.1",
+                                  "from": "sigmund@~1.0.0"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.1"
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@~1.0.2",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@~1.0.0"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@~0.10.x"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.1"
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "1.2.3",
+                          "from": "graceful-fs@1.2"
+                        }
+                      }
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@~0.5.0",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8"
+                        }
+                      }
+                    },
+                    "rc": {
+                      "version": "1.1.2",
+                      "from": "rc@~1.1.0",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@^1.1.2"
+                        },
+                        "deep-extend": {
+                          "version": "0.2.11",
+                          "from": "deep-extend@~0.2.5"
+                        },
+                        "strip-json-comments": {
+                          "version": "0.1.3",
+                          "from": "strip-json-comments@0.1.x"
+                        },
+                        "ini": {
+                          "version": "1.3.4",
+                          "from": "ini@~1.3.0"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.4.3",
+                      "from": "rimraf@~2.4.0",
+                      "dependencies": {
+                        "glob": {
+                          "version": "5.0.15",
+                          "from": "glob@^5.0.14",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@^1.0.4",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.1"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "minimatch@2 || 3",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.1",
+                                  "from": "brace-expansion@^1.0.0",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.2.0",
+                                      "from": "balanced-match@^0.2.0"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.2",
+                              "from": "once@^1.3.0",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "path-is-absolute@^1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "connect": {
+          "version": "3.4.0",
+          "from": "connect@>=3.4.0 <4.0.0",
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.2.0 <2.3.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1"
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.4.0",
+              "from": "finalhandler@0.4.0",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.2",
+                  "from": "escape-html@1.0.2"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1"
+                    }
+                  }
+                },
+                "unpipe": {
+                  "version": "1.0.0",
+                  "from": "unpipe@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0"
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0"
+            }
+          }
+        },
+        "dev-ip": {
+          "version": "1.0.1",
+          "from": "dev-ip@>=1.0.1 <2.0.0"
+        },
+        "easy-extender": {
+          "version": "2.3.1",
+          "from": "easy-extender@>=2.3.1 <3.0.0",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <3.0.0"
+            }
+          }
+        },
+        "eazy-logger": {
+          "version": "2.1.2",
+          "from": "eazy-logger@>=2.1.2 <3.0.0",
+          "dependencies": {
+            "opt-merger": {
+              "version": "1.1.0",
+              "from": "opt-merger@>=1.1.0 <2.0.0",
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.2",
+                  "from": "lodash@>=2.4.1 <3.0.0"
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.0 <2.0.0"
+                }
+              }
+            },
+            "tfunk": {
+              "version": "3.0.1",
+              "from": "tfunk@>=3.0.1 <4.0.0",
+              "dependencies": {
+                "chalk": {
+                  "version": "0.5.1",
+                  "from": "chalk@>=0.5.1 <0.6.0",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "1.1.0",
+                      "from": "ansi-styles@>=1.1.0 <2.0.0"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@>=1.0.0 <2.0.0"
+                    },
+                    "has-ansi": {
+                      "version": "0.1.0",
+                      "from": "has-ansi@>=0.1.0 <0.2.0",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "0.3.0",
+                      "from": "strip-ansi@>=0.3.0 <0.4.0",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "from": "supports-color@>=0.2.0 <0.3.0"
+                    }
+                  }
+                },
+                "object-path": {
+                  "version": "0.9.2",
+                  "from": "object-path@>=0.9.0 <0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "emitter-steward": {
+          "version": "1.0.0",
+          "from": "emitter-steward@>=1.0.0 <2.0.0"
+        },
+        "foxy": {
+          "version": "11.1.3",
+          "from": "foxy@>=11.1.2 <12.0.0",
+          "dependencies": {
+            "cookie": {
+              "version": "0.1.5",
+              "from": "cookie@>=0.1.3 <0.2.0"
+            },
+            "http-proxy": {
+              "version": "1.12.0",
+              "from": "http-proxy@>=1.9.0 <2.0.0",
+              "dependencies": {
+                "eventemitter3": {
+                  "version": "1.1.1",
+                  "from": "eventemitter3@>=1.0.0 <2.0.0"
+                },
+                "requires-port": {
+                  "version": "0.0.1",
+                  "from": "requires-port@>=0.0.0 <1.0.0"
+                }
+              }
+            },
+            "lodash.merge": {
+              "version": "3.3.2",
+              "from": "lodash.merge@>=3.3.1 <4.0.0",
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._arraycopy@>=3.0.0 <4.0.0"
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0",
+                  "from": "lodash._arrayeach@>=3.0.0 <4.0.0"
+                },
+                "lodash._createassigner": {
+                  "version": "3.1.1",
+                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0"
+                    },
+                    "lodash._isiterateecall": {
+                      "version": "3.0.9",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0"
+                    },
+                    "lodash.restparam": {
+                      "version": "3.6.1",
+                      "from": "lodash.restparam@>=3.0.0 <4.0.0"
+                    }
+                  }
+                },
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "from": "lodash._getnative@>=3.0.0 <4.0.0"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0"
+                },
+                "lodash.isplainobject": {
+                  "version": "3.2.0",
+                  "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "lodash._basefor": {
+                      "version": "3.0.2",
+                      "from": "lodash._basefor@>=3.0.0 <4.0.0"
+                    }
+                  }
+                },
+                "lodash.istypedarray": {
+                  "version": "3.0.2",
+                  "from": "lodash.istypedarray@>=3.0.0 <4.0.0"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0"
+                },
+                "lodash.keysin": {
+                  "version": "3.0.8",
+                  "from": "lodash.keysin@>=3.0.0 <4.0.0"
+                },
+                "lodash.toplainobject": {
+                  "version": "3.0.0",
+                  "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "resp-modifier": {
+              "version": "4.0.4",
+              "from": "resp-modifier@>=4.0.2 <5.0.0",
+              "dependencies": {
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "from": "balanced-match@>=0.2.0 <0.3.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "immutable": {
+          "version": "3.7.5",
+          "from": "immutable@>=3.7.4 <4.0.0"
+        },
+        "localtunnel": {
+          "version": "1.7.0",
+          "from": "localtunnel@>=1.7.0 <2.0.0",
+          "dependencies": {
+            "request": {
+              "version": "2.11.4",
+              "from": "request@2.11.4",
+              "dependencies": {
+                "form-data": {
+                  "version": "0.0.3",
+                  "from": "form-data",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.3",
+                      "from": "combined-stream@0.0.3",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
+                        }
+                      }
+                    },
+                    "async": {
+                      "version": "0.1.9",
+                      "from": "async@0.1.9"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.7",
+                  "from": "mime"
+                }
+              }
+            },
+            "yargs": {
+              "version": "3.15.0",
+              "from": "yargs@3.15.0",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "from": "camelcase@>=1.0.2 <2.0.0"
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "dependencies": {
+                    "center-align": {
+                      "version": "0.1.2",
+                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.3",
+                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "2.0.1",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.0",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0"
+                                }
+                              }
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "repeat-string@>=1.5.2 <2.0.0"
+                            }
+                          }
+                        },
+                        "lazy-cache": {
+                          "version": "0.2.4",
+                          "from": "lazy-cache@>=0.2.4 <0.3.0"
+                        }
+                      }
+                    },
+                    "right-align": {
+                      "version": "0.1.3",
+                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.3",
+                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "2.0.1",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.0",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0"
+                                }
+                              }
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "repeat-string@>=1.5.2 <2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2"
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.1.1",
+                  "from": "decamelize@>=1.0.0 <2.0.0"
+                },
+                "window-size": {
+                  "version": "0.1.2",
+                  "from": "window-size@>=0.1.1 <0.2.0"
+                }
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@0.7.4"
+            },
+            "openurl": {
+              "version": "1.1.0",
+              "from": "openurl@1.1.0"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.9.3 <4.0.0"
+        },
+        "longest": {
+          "version": "1.0.1",
+          "from": "longest@>=1.0.1 <2.0.0"
+        },
+        "meow": {
+          "version": "3.3.0",
+          "from": "meow@3.3.0",
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "1.0.0",
+              "from": "camelcase-keys@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "from": "camelcase@>=1.0.1 <2.0.0"
+                },
+                "map-obj": {
+                  "version": "1.0.1",
+                  "from": "map-obj@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "indent-string": {
+              "version": "1.2.2",
+              "from": "indent-string@>=1.1.0 <2.0.0",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0"
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "repeating@>=1.1.0 <2.0.0",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.0 <2.0.0"
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "from": "object-assign@>=3.0.0 <4.0.0"
+            }
+          }
+        },
+        "opn": {
+          "version": "3.0.2",
+          "from": "opn@>=3.0.2 <4.0.0",
+          "dependencies": {
+            "object-assign": {
+              "version": "3.0.0",
+              "from": "object-assign@>=3.0.0 <4.0.0"
+            }
+          }
+        },
+        "pad-left": {
+          "version": "2.0.0",
+          "from": "pad-left@>=2.0.0 <3.0.0",
+          "dependencies": {
+            "repeat-string": {
+              "version": "1.5.2",
+              "from": "repeat-string@>=1.5.2 <2.0.0"
+            }
+          }
+        },
+        "portscanner": {
+          "version": "1.0.0",
+          "from": "portscanner@>=1.0.0 <2.0.0",
+          "dependencies": {
+            "async": {
+              "version": "0.1.15",
+              "from": "async@0.1.15"
+            }
+          }
+        },
+        "query-string": {
+          "version": "2.4.2",
+          "from": "query-string@>=2.4.0 <3.0.0",
+          "dependencies": {
+            "strict-uri-encode": {
+              "version": "1.0.2",
+              "from": "strict-uri-encode@>=1.0.0 <2.0.0"
+            }
+          }
+        },
+        "resp-modifier": {
+          "version": "5.0.2",
+          "from": "resp-modifier@>=5.0.0 <6.0.0",
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.2.0 <3.0.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.1",
+                      "from": "balanced-match@>=0.2.0 <0.3.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "serve-index": {
+          "version": "1.7.2",
+          "from": "serve-index@>=1.7.0 <2.0.0",
+          "dependencies": {
+            "accepts": {
+              "version": "1.2.13",
+              "from": "accepts@>=1.2.12 <1.3.0",
+              "dependencies": {
+                "negotiator": {
+                  "version": "0.5.3",
+                  "from": "negotiator@0.5.3"
+                }
+              }
+            },
+            "batch": {
+              "version": "0.5.2",
+              "from": "batch@0.5.2"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.2.0 <2.3.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1"
+                }
+              }
+            },
+            "escape-html": {
+              "version": "1.0.2",
+              "from": "escape-html@1.0.2"
+            },
+            "http-errors": {
+              "version": "1.3.1",
+              "from": "http-errors@>=1.3.1 <1.4.0",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "mime-types": {
+              "version": "2.1.7",
+              "from": "mime-types@>=2.1.4 <2.2.0",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.19.0",
+                  "from": "mime-db@>=1.19.0 <1.20.0"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.10.0",
+          "from": "serve-static@>=1.10.0 <2.0.0",
+          "dependencies": {
+            "escape-html": {
+              "version": "1.0.2",
+              "from": "escape-html@1.0.2"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0"
+            },
+            "send": {
+              "version": "0.13.0",
+              "from": "send@0.13.0",
+              "dependencies": {
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@>=2.2.0 <2.3.0"
+                },
+                "depd": {
+                  "version": "1.0.1",
+                  "from": "depd@>=1.0.1 <1.1.0"
+                },
+                "destroy": {
+                  "version": "1.0.3",
+                  "from": "destroy@1.0.3"
+                },
+                "etag": {
+                  "version": "1.7.0",
+                  "from": "etag@>=1.7.0 <1.8.0"
+                },
+                "fresh": {
+                  "version": "0.3.0",
+                  "from": "fresh@0.3.0"
+                },
+                "http-errors": {
+                  "version": "1.3.1",
+                  "from": "http-errors@>=1.3.1 <1.4.0",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "from": "mime@1.3.4"
+                },
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1"
+                    }
+                  }
+                },
+                "range-parser": {
+                  "version": "1.0.2",
+                  "from": "range-parser@>=1.0.2 <1.1.0"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@>=1.2.1 <1.3.0"
+                }
+              }
+            }
+          }
+        },
+        "socket.io": {
+          "version": "1.3.7",
+          "from": "socket.io@>=1.3.7 <2.0.0",
+          "dependencies": {
+            "engine.io": {
+              "version": "1.5.4",
+              "from": "engine.io@1.5.4",
+              "dependencies": {
+                "base64id": {
+                  "version": "0.1.0",
+                  "from": "base64id@0.1.0"
+                },
+                "debug": {
+                  "version": "1.0.3",
+                  "from": "debug@1.0.3",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2"
+                    }
+                  }
+                },
+                "engine.io-parser": {
+                  "version": "1.2.2",
+                  "from": "engine.io-parser@1.2.2",
+                  "dependencies": {
+                    "after": {
+                      "version": "0.8.1",
+                      "from": "after@0.8.1"
+                    },
+                    "arraybuffer.slice": {
+                      "version": "0.0.6",
+                      "from": "arraybuffer.slice@0.0.6"
+                    },
+                    "base64-arraybuffer": {
+                      "version": "0.1.2",
+                      "from": "base64-arraybuffer@0.1.2"
+                    },
+                    "blob": {
+                      "version": "0.0.4",
+                      "from": "blob@0.0.4"
+                    },
+                    "has-binary": {
+                      "version": "0.1.6",
+                      "from": "has-binary@0.1.6",
+                      "dependencies": {
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1"
+                        }
+                      }
+                    },
+                    "utf8": {
+                      "version": "2.1.0",
+                      "from": "utf8@2.1.0"
+                    }
+                  }
+                },
+                "ws": {
+                  "version": "0.8.0",
+                  "from": "ws@0.8.0",
+                  "dependencies": {
+                    "options": {
+                      "version": "0.0.6",
+                      "from": "options@>=0.0.5"
+                    },
+                    "ultron": {
+                      "version": "1.0.2",
+                      "from": "ultron@>=1.0.0 <1.1.0"
+                    },
+                    "bufferutil": {
+                      "version": "1.2.1",
+                      "from": "bufferutil@>=1.2.0 <1.3.0",
+                      "dependencies": {
+                        "bindings": {
+                          "version": "1.2.1",
+                          "from": "bindings@>=1.2.0 <1.3.0"
+                        },
+                        "nan": {
+                          "version": "2.1.0",
+                          "from": "nan@>=2.0.5 <3.0.0"
+                        }
+                      }
+                    },
+                    "utf-8-validate": {
+                      "version": "1.2.1",
+                      "from": "utf-8-validate@>=1.2.0 <1.3.0",
+                      "dependencies": {
+                        "bindings": {
+                          "version": "1.2.1",
+                          "from": "bindings@>=1.2.0 <1.3.0"
+                        },
+                        "nan": {
+                          "version": "2.1.0",
+                          "from": "nan@>=2.0.5 <3.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "socket.io-parser": {
+              "version": "2.2.4",
+              "from": "socket.io-parser@2.2.4",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@0.7.4"
+                },
+                "json3": {
+                  "version": "3.2.6",
+                  "from": "json3@3.2.6"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "component-emitter@1.1.2"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "benchmark": {
+                  "version": "1.0.0",
+                  "from": "benchmark@1.0.0"
+                }
+              }
+            },
+            "socket.io-client": {
+              "version": "1.3.7",
+              "from": "socket.io-client@1.3.7",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@0.7.4"
+                },
+                "engine.io-client": {
+                  "version": "1.5.4",
+                  "from": "engine.io-client@1.5.4",
+                  "dependencies": {
+                    "component-inherit": {
+                      "version": "0.0.3",
+                      "from": "component-inherit@0.0.3"
+                    },
+                    "debug": {
+                      "version": "1.0.4",
+                      "from": "debug@1.0.4",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.6.2",
+                          "from": "ms@0.6.2"
+                        }
+                      }
+                    },
+                    "engine.io-parser": {
+                      "version": "1.2.2",
+                      "from": "engine.io-parser@1.2.2",
+                      "dependencies": {
+                        "after": {
+                          "version": "0.8.1",
+                          "from": "after@0.8.1"
+                        },
+                        "arraybuffer.slice": {
+                          "version": "0.0.6",
+                          "from": "arraybuffer.slice@0.0.6"
+                        },
+                        "base64-arraybuffer": {
+                          "version": "0.1.2",
+                          "from": "base64-arraybuffer@0.1.2"
+                        },
+                        "blob": {
+                          "version": "0.0.4",
+                          "from": "blob@0.0.4"
+                        },
+                        "utf8": {
+                          "version": "2.1.0",
+                          "from": "utf8@2.1.0"
+                        }
+                      }
+                    },
+                    "has-cors": {
+                      "version": "1.0.3",
+                      "from": "has-cors@1.0.3",
+                      "dependencies": {
+                        "global": {
+                          "version": "2.0.1",
+                          "from": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+                        }
+                      }
+                    },
+                    "parsejson": {
+                      "version": "0.0.1",
+                      "from": "parsejson@0.0.1",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "parseqs": {
+                      "version": "0.0.2",
+                      "from": "parseqs@0.0.2",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "parseuri": {
+                      "version": "0.0.4",
+                      "from": "parseuri@0.0.4",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ws": {
+                      "version": "0.8.0",
+                      "from": "ws@0.8.0",
+                      "dependencies": {
+                        "options": {
+                          "version": "0.0.6",
+                          "from": "options@>=0.0.5"
+                        },
+                        "ultron": {
+                          "version": "1.0.2",
+                          "from": "ultron@>=1.0.0 <1.1.0"
+                        },
+                        "bufferutil": {
+                          "version": "1.2.1",
+                          "from": "bufferutil@>=1.2.0 <1.3.0",
+                          "dependencies": {
+                            "bindings": {
+                              "version": "1.2.1",
+                              "from": "bindings@>=1.2.0 <1.3.0"
+                            },
+                            "nan": {
+                              "version": "2.1.0",
+                              "from": "nan@>=2.0.5 <3.0.0"
+                            }
+                          }
+                        },
+                        "utf-8-validate": {
+                          "version": "1.2.1",
+                          "from": "utf-8-validate@>=1.2.0 <1.3.0",
+                          "dependencies": {
+                            "bindings": {
+                              "version": "1.2.1",
+                              "from": "bindings@>=1.2.0 <1.3.0"
+                            },
+                            "nan": {
+                              "version": "2.1.0",
+                              "from": "nan@>=2.0.5 <3.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "xmlhttprequest": {
+                      "version": "1.5.0",
+                      "from": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
+                    }
+                  }
+                },
+                "component-bind": {
+                  "version": "1.0.0",
+                  "from": "component-bind@1.0.0"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "component-emitter@1.1.2"
+                },
+                "object-component": {
+                  "version": "0.0.3",
+                  "from": "object-component@0.0.3"
+                },
+                "has-binary": {
+                  "version": "0.1.6",
+                  "from": "has-binary@0.1.6",
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    }
+                  }
+                },
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1"
+                },
+                "parseuri": {
+                  "version": "0.0.2",
+                  "from": "parseuri@0.0.2",
+                  "dependencies": {
+                    "better-assert": {
+                      "version": "1.0.2",
+                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "dependencies": {
+                        "callsite": {
+                          "version": "1.0.0",
+                          "from": "callsite@1.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-array": {
+                  "version": "0.1.3",
+                  "from": "to-array@0.1.3"
+                },
+                "backo2": {
+                  "version": "1.0.2",
+                  "from": "backo2@1.0.2"
+                }
+              }
+            },
+            "socket.io-adapter": {
+              "version": "0.3.1",
+              "from": "socket.io-adapter@0.3.1",
+              "dependencies": {
+                "debug": {
+                  "version": "1.0.2",
+                  "from": "debug@1.0.2",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2"
+                    }
+                  }
+                },
+                "socket.io-parser": {
+                  "version": "2.2.2",
+                  "from": "socket.io-parser@2.2.2",
+                  "dependencies": {
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@0.7.4"
+                    },
+                    "json3": {
+                      "version": "3.2.6",
+                      "from": "json3@3.2.6"
+                    },
+                    "component-emitter": {
+                      "version": "1.1.2",
+                      "from": "component-emitter@1.1.2"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    },
+                    "benchmark": {
+                      "version": "1.0.0",
+                      "from": "benchmark@1.0.0"
+                    }
+                  }
+                },
+                "object-keys": {
+                  "version": "1.0.1",
+                  "from": "object-keys@1.0.1"
+                }
+              }
+            },
+            "has-binary-data": {
+              "version": "0.1.3",
+              "from": "has-binary-data@0.1.3",
+              "dependencies": {
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                }
+              }
+            },
+            "debug": {
+              "version": "2.1.0",
+              "from": "debug@2.1.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2"
+                }
+              }
+            }
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.9",
+          "from": "ua-parser-js@>=0.7.9 <0.8.0"
+        },
+        "ucfirst": {
+          "version": "1.0.0",
+          "from": "ucfirst@>=1.0.0 <2.0.0"
+        }
+      }
+    },
+    "gulp": {
+      "version": "3.9.0",
+      "from": "gulp@>=3.8.8 <4.0.0",
+      "dependencies": {
+        "archy": {
+          "version": "1.0.0",
+          "from": "archy@>=1.0.0 <2.0.0"
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0"
+            }
+          }
+        },
+        "deprecated": {
+          "version": "0.0.1",
+          "from": "deprecated@>=0.0.1 <0.0.2"
+        },
+        "interpret": {
+          "version": "0.6.6",
+          "from": "interpret@>=0.6.2 <0.7.0"
+        },
+        "liftoff": {
+          "version": "2.2.0",
+          "from": "liftoff@>=2.1.0 <3.0.0",
+          "dependencies": {
+            "extend": {
+              "version": "2.0.1",
+              "from": "extend@>=2.0.1 <3.0.0"
+            },
+            "findup-sync": {
+              "version": "0.3.0",
+              "from": "findup-sync@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "glob@>=5.0.0 <5.1.0",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.1",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.1",
+                              "from": "balanced-match@>=0.2.0 <0.3.0"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "flagged-respawn": {
+              "version": "0.3.1",
+              "from": "flagged-respawn@>=0.3.1 <0.4.0"
+            },
+            "rechoir": {
+              "version": "0.6.2",
+              "from": "rechoir@>=0.6.0 <0.7.0"
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "from": "resolve@>=1.1.6 <2.0.0"
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.1.0 <2.0.0"
+        },
+        "orchestrator": {
+          "version": "0.3.7",
+          "from": "orchestrator@>=0.3.0 <0.4.0",
+          "dependencies": {
+            "end-of-stream": {
+              "version": "0.1.5",
+              "from": "end-of-stream@>=0.1.5 <0.2.0",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "sequencify": {
+              "version": "0.0.7",
+              "from": "sequencify@>=0.0.7 <0.1.0"
+            },
+            "stream-consume": {
+              "version": "0.1.0",
+              "from": "stream-consume@>=0.1.0 <0.2.0"
+            }
+          }
+        },
+        "pretty-hrtime": {
+          "version": "1.0.1",
+          "from": "pretty-hrtime@>=1.0.0 <2.0.0"
+        },
+        "semver": {
+          "version": "4.3.6",
+          "from": "semver@>=4.1.0 <5.0.0"
+        },
+        "tildify": {
+          "version": "1.1.2",
+          "from": "tildify@>=1.0.0 <2.0.0",
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.1",
+              "from": "os-homedir@>=1.0.0 <2.0.0"
+            }
+          }
+        },
+        "v8flags": {
+          "version": "2.0.10",
+          "from": "v8flags@>=2.0.2 <3.0.0",
+          "dependencies": {
+            "user-home": {
+              "version": "1.1.1",
+              "from": "user-home@>=1.1.1 <2.0.0"
+            }
+          }
+        },
+        "vinyl-fs": {
+          "version": "0.3.14",
+          "from": "vinyl-fs@>=0.3.0 <0.4.0",
+          "dependencies": {
+            "defaults": {
+              "version": "1.0.3",
+              "from": "defaults@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.2",
+                  "from": "clone@>=1.0.2 <2.0.0"
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "3.1.18",
+              "from": "glob-stream@>=3.1.5 <4.0.0",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.3.1 <5.0.0",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0"
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "from": "balanced-match@>=0.2.0 <0.3.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "from": "ordered-read-streams@>=0.1.0 <0.2.0"
+                },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "from": "glob2base@>=0.0.12 <0.0.13",
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "from": "find-index@>=0.1.1 <0.2.0"
+                    }
+                  }
+                },
+                "unique-stream": {
+                  "version": "1.0.0",
+                  "from": "unique-stream@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.6",
+              "from": "glob-watcher@>=0.0.6 <0.0.7",
+              "dependencies": {
+                "gaze": {
+                  "version": "0.5.2",
+                  "from": "gaze@>=0.5.1 <0.6.0",
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "from": "globule@>=0.1.0 <0.2.0",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "1.0.2",
+                          "from": "lodash@>=1.0.1 <1.1.0"
+                        },
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "glob@>=3.1.21 <3.2.0",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@>=1.2.0 <1.3.0"
+                            },
+                            "inherits": {
+                              "version": "1.0.2",
+                              "from": "inherits@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@>=0.2.11 <0.3.0",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.0",
+                              "from": "lru-cache@>=2.0.0 <3.0.0"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "sigmund@>=1.0.0 <1.1.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.8",
+              "from": "graceful-fs@>=3.0.0 <4.0.0"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8"
+                }
+              }
+            },
+            "strip-bom": {
+              "version": "1.0.0",
+              "from": "strip-bom@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "first-chunk-stream": {
+                  "version": "1.0.0",
+                  "from": "first-chunk-stream@>=1.0.0 <2.0.0"
+                },
+                "is-utf8": {
+                  "version": "0.2.0",
+                  "from": "is-utf8@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.5",
+              "from": "through2@>=0.6.1 <0.7.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@>=0.4.0 <0.5.0",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@>=0.2.0 <0.3.0"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.0.2"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-bump": {
+      "version": "0.3.1",
+      "from": "gulp-bump@>=0.3.1 <0.4.0",
+      "dependencies": {
+        "dot-object": {
+          "version": "0.6.0",
+          "from": "dot-object@>=0.6.0 <0.7.0",
+          "dependencies": {
+            "commander": {
+              "version": "2.9.0",
+              "from": "commander@>=2.5.0 <3.0.0",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "4.3.6",
+          "from": "semver@>=4.3.1 <5.0.0"
+        },
+        "through2": {
+          "version": "0.5.1",
+          "from": "through2@>=0.5.1 <0.6.0",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                }
+              }
+            },
+            "xtend": {
+              "version": "3.0.0",
+              "from": "xtend@>=3.0.0 <3.1.0"
+            }
+          }
+        }
+      }
+    },
+    "gulp-filter": {
+      "version": "2.0.2",
+      "from": "gulp-filter@>=2.0.2 <3.0.0",
+      "dependencies": {
+        "merge-stream": {
+          "version": "0.1.8",
+          "from": "merge-stream@>=0.1.7 <0.2.0"
+        },
+        "multimatch": {
+          "version": "2.0.0",
+          "from": "multimatch@>=2.0.0 <3.0.0",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0"
+            },
+            "array-union": {
+              "version": "1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2",
+                  "from": "array-uniq@>=1.0.1 <2.0.0"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.1",
+                      "from": "balanced-match@>=0.2.0 <0.3.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "plexer": {
+          "version": "0.0.3",
+          "from": "plexer@0.0.3",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.0.26-2 <2.0.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0"
+            }
+          }
+        }
+      }
+    },
+    "gulp-git": {
+      "version": "1.6.0",
+      "from": "gulp-git@>=1.2.4 <2.0.0",
+      "dependencies": {
+        "any-shell-escape": {
+          "version": "0.1.1",
+          "from": "any-shell-escape@>=0.1.1 <0.2.0"
+        },
+        "require-dir": {
+          "version": "0.1.0",
+          "from": "require-dir@>=0.1.0 <0.2.0"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.5 <0.7.0",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0"
+            }
+          }
+        }
+      }
+    },
+    "gulp-notify": {
+      "version": "2.2.0",
+      "from": "gulp-notify@>=2.2.0 <3.0.0",
+      "dependencies": {
+        "lodash.template": {
+          "version": "3.6.2",
+          "from": "lodash.template@>=3.0.0 <4.0.0",
+          "dependencies": {
+            "lodash._basecopy": {
+              "version": "3.0.1",
+              "from": "lodash._basecopy@>=3.0.0 <4.0.0"
+            },
+            "lodash._basetostring": {
+              "version": "3.0.1",
+              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
+            },
+            "lodash._basevalues": {
+              "version": "3.0.0",
+              "from": "lodash._basevalues@>=3.0.0 <4.0.0"
+            },
+            "lodash._isiterateecall": {
+              "version": "3.0.9",
+              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@>=3.0.0 <4.0.0"
+            },
+            "lodash.escape": {
+              "version": "3.0.0",
+              "from": "lodash.escape@>=3.0.0 <4.0.0"
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "from": "lodash._getnative@>=3.0.0 <4.0.0"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0"
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0"
+            },
+            "lodash.templatesettings": {
+              "version": "3.1.0",
+              "from": "lodash.templatesettings@>=3.0.0 <4.0.0"
+            }
+          }
+        },
+        "node-notifier": {
+          "version": "4.3.1",
+          "from": "node-notifier@>=4.1.0 <5.0.0",
+          "dependencies": {
+            "cli-usage": {
+              "version": "0.1.2",
+              "from": "cli-usage@>=0.1.1 <0.2.0",
+              "dependencies": {
+                "marked": {
+                  "version": "0.3.5",
+                  "from": "marked@>=0.3.2 <0.4.0"
+                },
+                "marked-terminal": {
+                  "version": "1.6.1",
+                  "from": "marked-terminal@>=1.6.1 <2.0.0",
+                  "dependencies": {
+                    "cardinal": {
+                      "version": "0.5.0",
+                      "from": "cardinal@>=0.5.0 <0.6.0",
+                      "dependencies": {
+                        "redeyed": {
+                          "version": "0.5.0",
+                          "from": "redeyed@>=0.5.0 <0.6.0",
+                          "dependencies": {
+                            "esprima-fb": {
+                              "version": "12001.1.0-dev-harmony-fb",
+                              "from": "esprima-fb@>=12001.1.0-dev-harmony-fb <12001.2.0"
+                            }
+                          }
+                        },
+                        "ansicolors": {
+                          "version": "0.2.1",
+                          "from": "ansicolors@>=0.2.1 <0.3.0"
+                        }
+                      }
+                    },
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.1.0",
+                          "from": "ansi-styles@>=2.1.0 <3.0.0"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.0",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0"
+                        }
+                      }
+                    },
+                    "cli-table": {
+                      "version": "0.3.1",
+                      "from": "cli-table@>=0.3.1 <0.4.0",
+                      "dependencies": {
+                        "colors": {
+                          "version": "1.0.3",
+                          "from": "colors@1.0.3"
+                        }
+                      }
+                    },
+                    "lodash.assign": {
+                      "version": "3.2.0",
+                      "from": "lodash.assign@>=3.0.0 <4.0.0",
+                      "dependencies": {
+                        "lodash._baseassign": {
+                          "version": "3.2.0",
+                          "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                          "dependencies": {
+                            "lodash._basecopy": {
+                              "version": "3.0.1",
+                              "from": "lodash._basecopy@>=3.0.0 <4.0.0"
+                            }
+                          }
+                        },
+                        "lodash._createassigner": {
+                          "version": "3.1.1",
+                          "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                          "dependencies": {
+                            "lodash._bindcallback": {
+                              "version": "3.0.1",
+                              "from": "lodash._bindcallback@>=3.0.0 <4.0.0"
+                            },
+                            "lodash._isiterateecall": {
+                              "version": "3.0.9",
+                              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0"
+                            },
+                            "lodash.restparam": {
+                              "version": "3.6.1",
+                              "from": "lodash.restparam@>=3.0.0 <4.0.0"
+                            }
+                          }
+                        },
+                        "lodash.keys": {
+                          "version": "3.1.2",
+                          "from": "lodash.keys@>=3.0.0 <4.0.0",
+                          "dependencies": {
+                            "lodash._getnative": {
+                              "version": "3.9.1",
+                              "from": "lodash._getnative@>=3.0.0 <4.0.0"
+                            },
+                            "lodash.isarguments": {
+                              "version": "3.0.4",
+                              "from": "lodash.isarguments@>=3.0.0 <4.0.0"
+                            },
+                            "lodash.isarray": {
+                              "version": "3.0.4",
+                              "from": "lodash.isarray@>=3.0.0 <4.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "node-emoji": {
+                      "version": "0.1.0",
+                      "from": "node-emoji@>=0.1.0 <0.2.0"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "0.2.0",
+                  "from": "minimist@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "growly": {
+              "version": "1.2.0",
+              "from": "growly@>=1.2.0 <2.0.0"
+            },
+            "lodash.clonedeep": {
+              "version": "3.0.2",
+              "from": "lodash.clonedeep@>=3.0.0 <4.0.0",
+              "dependencies": {
+                "lodash._baseclone": {
+                  "version": "3.3.0",
+                  "from": "lodash._baseclone@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "lodash._arraycopy": {
+                      "version": "3.0.0",
+                      "from": "lodash._arraycopy@>=3.0.0 <4.0.0"
+                    },
+                    "lodash._arrayeach": {
+                      "version": "3.0.0",
+                      "from": "lodash._arrayeach@>=3.0.0 <4.0.0"
+                    },
+                    "lodash._baseassign": {
+                      "version": "3.2.0",
+                      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "from": "lodash._basecopy@>=3.0.0 <4.0.0"
+                        }
+                      }
+                    },
+                    "lodash._basefor": {
+                      "version": "3.0.2",
+                      "from": "lodash._basefor@>=3.0.0 <4.0.0"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0"
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "from": "lodash.keys@>=3.0.0 <4.0.0",
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "lodash._getnative@>=3.0.0 <4.0.0"
+                        },
+                        "lodash.isarguments": {
+                          "version": "3.0.4",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.1 <2.0.0"
+            },
+            "semver": {
+              "version": "4.3.6",
+              "from": "semver@>=4.0.3 <5.0.0"
+            },
+            "shellwords": {
+              "version": "0.1.0",
+              "from": "shellwords@>=0.1.0 <0.2.0"
+            },
+            "which": {
+              "version": "1.2.0",
+              "from": "which@>=1.0.5 <2.0.0",
+              "dependencies": {
+                "is-absolute": {
+                  "version": "0.1.7",
+                  "from": "is-absolute@>=0.1.7 <0.2.0",
+                  "dependencies": {
+                    "is-relative": {
+                      "version": "0.1.3",
+                      "from": "is-relative@>=0.1.0 <0.2.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "node.extend": {
+          "version": "1.1.5",
+          "from": "node.extend@>=1.1.3 <2.0.0",
+          "dependencies": {
+            "is": {
+              "version": "3.1.0",
+              "from": "is@>=3.0.1 <4.0.0"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.3 <0.7.0",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0"
+            }
+          }
+        }
+      }
+    },
+    "gulp-sass": {
+      "version": "2.1.0",
+      "from": "gulp-sass@>=2.0.2 <3.0.0",
+      "dependencies": {
+        "node-sass": {
+          "version": "3.3.3",
+          "from": "node-sass@>=3.3.3",
+          "dependencies": {
+            "async-foreach": {
+              "version": "0.1.3",
+              "from": "async-foreach@>=0.1.3 <0.2.0"
+            },
+            "chalk": {
+              "version": "1.1.1",
+              "from": "chalk@>=1.1.1 <2.0.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0"
+                }
+              }
+            },
+            "cross-spawn": {
+              "version": "2.0.0",
+              "from": "cross-spawn@>=2.0.0 <3.0.0",
+              "dependencies": {
+                "cross-spawn-async": {
+                  "version": "2.0.0",
+                  "from": "cross-spawn-async@>=2.0.0 <3.0.0",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.0",
+                      "from": "lru-cache@>=2.6.5 <3.0.0"
+                    },
+                    "which": {
+                      "version": "1.2.0",
+                      "from": "which@>=1.1.1 <2.0.0",
+                      "dependencies": {
+                        "is-absolute": {
+                          "version": "0.1.7",
+                          "from": "is-absolute@>=0.1.7 <0.2.0",
+                          "dependencies": {
+                            "is-relative": {
+                              "version": "0.1.3",
+                              "from": "is-relative@>=0.1.0 <0.2.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "spawn-sync": {
+                  "version": "1.0.13",
+                  "from": "spawn-sync@>=1.0.13 <2.0.0",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.5.1",
+                      "from": "concat-stream@>=1.4.7 <2.0.0",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "typedarray@>=0.0.5 <0.1.0"
+                        },
+                        "readable-stream": {
+                          "version": "2.0.3",
+                          "from": "readable-stream@>=2.0.0 <2.1.0",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.3",
+                              "from": "process-nextick-args@>=1.0.0 <1.1.0"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "os-shim": {
+                      "version": "0.1.3",
+                      "from": "os-shim@>=0.1.2 <0.2.0"
+                    }
+                  }
+                }
+              }
+            },
+            "gaze": {
+              "version": "0.5.2",
+              "from": "gaze@>=0.5.1 <0.6.0",
+              "dependencies": {
+                "globule": {
+                  "version": "0.1.0",
+                  "from": "globule@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "1.0.2",
+                      "from": "lodash@>=1.0.1 <1.1.0"
+                    },
+                    "glob": {
+                      "version": "3.1.21",
+                      "from": "glob@>=3.1.21 <3.2.0",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "1.2.3",
+                          "from": "graceful-fs@>=1.2.0 <1.3.0"
+                        },
+                        "inherits": {
+                          "version": "1.0.2",
+                          "from": "inherits@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.7.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@>=5.0.14 <6.0.0",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0"
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "from": "balanced-match@>=0.2.0 <0.3.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "meow": {
+              "version": "3.4.2",
+              "from": "meow@>=3.3.0 <4.0.0",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "loud-rejection": {
+                  "version": "1.0.0",
+                  "from": "loud-rejection@>=1.0.0 <2.0.0"
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.3 <2.0.0"
+                },
+                "normalize-package-data": {
+                  "version": "2.3.4",
+                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                  "dependencies": {
+                    "hosted-git-info": {
+                      "version": "2.1.4",
+                      "from": "hosted-git-info@>=2.0.2 <3.0.0"
+                    },
+                    "is-builtin-module": {
+                      "version": "1.0.0",
+                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "builtin-modules": {
+                          "version": "1.1.0",
+                          "from": "builtin-modules@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "5.0.3",
+                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0"
+                    },
+                    "validate-npm-package-license": {
+                      "version": "3.0.1",
+                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                      "dependencies": {
+                        "spdx-correct": {
+                          "version": "1.0.2",
+                          "from": "spdx-correct@>=1.0.0 <1.1.0",
+                          "dependencies": {
+                            "spdx-license-ids": {
+                              "version": "1.1.0",
+                              "from": "spdx-license-ids@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "spdx-expression-parse": {
+                          "version": "1.0.0",
+                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                          "dependencies": {
+                            "spdx-exceptions": {
+                              "version": "1.0.3",
+                              "from": "spdx-exceptions@>=1.0.0 <2.0.0"
+                            },
+                            "spdx-license-ids": {
+                              "version": "1.1.0",
+                              "from": "spdx-license-ids@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "read-pkg-up": {
+                  "version": "1.0.1",
+                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                  "dependencies": {
+                    "find-up": {
+                      "version": "1.0.0",
+                      "from": "find-up@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "path-exists": {
+                          "version": "2.0.0",
+                          "from": "path-exists@>=2.0.0 <3.0.0"
+                        },
+                        "pinkie-promise": {
+                          "version": "1.0.0",
+                          "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "1.0.0",
+                              "from": "pinkie@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "read-pkg": {
+                      "version": "1.1.0",
+                      "from": "read-pkg@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "load-json-file": {
+                          "version": "1.0.1",
+                          "from": "load-json-file@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.2",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0"
+                            },
+                            "parse-json": {
+                              "version": "2.2.0",
+                              "from": "parse-json@>=2.2.0 <3.0.0",
+                              "dependencies": {
+                                "error-ex": {
+                                  "version": "1.2.0",
+                                  "from": "error-ex@>=1.2.0 <2.0.0"
+                                }
+                              }
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "from": "pify@>=2.0.0 <3.0.0"
+                            },
+                            "pinkie-promise": {
+                              "version": "1.0.0",
+                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            },
+                            "strip-bom": {
+                              "version": "2.0.0",
+                              "from": "strip-bom@>=2.0.0 <3.0.0",
+                              "dependencies": {
+                                "is-utf8": {
+                                  "version": "0.2.0",
+                                  "from": "is-utf8@>=0.2.0 <0.3.0"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-type": {
+                          "version": "1.0.0",
+                          "from": "path-type@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.2",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0"
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "from": "pify@>=2.0.0 <3.0.0"
+                            },
+                            "pinkie-promise": {
+                              "version": "1.0.0",
+                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "redent": {
+                  "version": "1.0.0",
+                  "from": "redent@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "indent-string": {
+                      "version": "2.1.0",
+                      "from": "indent-string@>=2.1.0 <3.0.0",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "2.0.0",
+                          "from": "repeating@>=2.0.0 <3.0.0",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-indent": {
+                      "version": "1.0.1",
+                      "from": "strip-indent@>=1.0.1 <2.0.0"
+                    }
+                  }
+                },
+                "trim-newlines": {
+                  "version": "1.0.0",
+                  "from": "trim-newlines@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8"
+                }
+              }
+            },
+            "nan": {
+              "version": "2.1.0",
+              "from": "nan@>=2.0.8 <3.0.0"
+            },
+            "npmconf": {
+              "version": "2.1.2",
+              "from": "npmconf@>=2.1.2 <3.0.0",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.9",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "dependencies": {
+                    "proto-list": {
+                      "version": "1.2.4",
+                      "from": "proto-list@>=1.2.1 <1.3.0"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <2.1.0"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@>=1.2.0 <2.0.0"
+                },
+                "nopt": {
+                  "version": "3.0.4",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.3",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1",
+                      "from": "os-homedir@>=1.0.0 <2.0.0"
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "4.3.6",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0"
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "uid-number@0.0.5"
+                }
+              }
+            },
+            "node-gyp": {
+              "version": "3.0.3",
+              "from": "node-gyp@>=3.0.1 <4.0.0",
+              "dependencies": {
+                "fstream": {
+                  "version": "1.0.8",
+                  "from": "fstream@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <2.1.0"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0"
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.1",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.1",
+                              "from": "balanced-match@>=0.2.0 <0.3.0"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.2",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0"
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "minimatch@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.4",
+                  "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "1.2.1",
+                  "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "ansi": {
+                      "version": "0.3.0",
+                      "from": "ansi@>=0.3.0 <0.4.0"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.0.4",
+                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                      "dependencies": {
+                        "delegates": {
+                          "version": "0.1.0",
+                          "from": "delegates@>=0.1.0 <0.2.0"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "readable-stream@>=1.1.13 <2.0.0",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "gauge": {
+                      "version": "1.2.2",
+                      "from": "gauge@>=1.2.0 <1.3.0",
+                      "dependencies": {
+                        "has-unicode": {
+                          "version": "1.0.1",
+                          "from": "has-unicode@>=1.0.0 <2.0.0"
+                        },
+                        "lodash.pad": {
+                          "version": "3.1.1",
+                          "from": "lodash.pad@>=3.0.0 <4.0.0",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padleft": {
+                          "version": "3.1.1",
+                          "from": "lodash.padleft@>=3.0.0 <4.0.0",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padright": {
+                          "version": "3.1.1",
+                          "from": "lodash.padright@>=3.0.0 <4.0.0",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.3",
+                  "from": "osenv@>=0.0.0 <1.0.0",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1",
+                      "from": "os-homedir@>=1.0.0 <2.0.0"
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "path-array": {
+                  "version": "1.0.0",
+                  "from": "path-array@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "array-index": {
+                      "version": "0.1.1",
+                      "from": "array-index@>=0.1.0 <0.2.0",
+                      "dependencies": {
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@*",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.4.3",
+                  "from": "rimraf@>=2.0.0 <3.0.0",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "glob@>=5.0.14 <6.0.0",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.1",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.1",
+                                  "from": "balanced-match@>=0.2.0 <0.3.0"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "path-is-absolute@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "5.0.3",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0"
+                },
+                "tar": {
+                  "version": "1.0.3",
+                  "from": "tar@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.8",
+                      "from": "block-stream@*"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0"
+                    }
+                  }
+                },
+                "which": {
+                  "version": "1.2.0",
+                  "from": "which@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "is-absolute": {
+                      "version": "0.1.7",
+                      "from": "is-absolute@>=0.1.7 <0.2.0",
+                      "dependencies": {
+                        "is-relative": {
+                          "version": "0.1.3",
+                          "from": "is-relative@>=0.1.0 <0.2.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "request": {
+              "version": "2.65.0",
+              "from": "request@>=2.61.0 <3.0.0",
+              "dependencies": {
+                "bl": {
+                  "version": "1.0.0",
+                  "from": "bl@>=1.0.0 <1.1.0",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.3",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.3",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "caseless@>=0.11.0 <0.12.0"
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "from": "extend@>=3.0.0 <3.1.0"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@>=0.6.1 <0.7.0"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3",
+                  "from": "form-data@>=1.0.0-rc3 <1.1.0",
+                  "dependencies": {
+                    "async": {
+                      "version": "1.5.0",
+                      "from": "async@>=1.4.0 <2.0.0"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.1 <5.1.0"
+                },
+                "mime-types": {
+                  "version": "2.1.7",
+                  "from": "mime-types@>=2.1.7 <2.2.0",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.19.0",
+                      "from": "mime-db@>=1.19.0 <1.20.0"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.3 <1.5.0"
+                },
+                "qs": {
+                  "version": "5.2.0",
+                  "from": "qs@>=5.2.0 <5.3.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1",
+                  "from": "tunnel-agent@>=0.4.1 <0.5.0"
+                },
+                "tough-cookie": {
+                  "version": "2.2.0",
+                  "from": "tough-cookie@>=2.2.0 <2.3.0"
+                },
+                "http-signature": {
+                  "version": "0.11.0",
+                  "from": "http-signature@>=0.11.0 <0.12.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "from": "oauth-sign@>=0.8.0 <0.9.0"
+                },
+                "hawk": {
+                  "version": "3.1.0",
+                  "from": "hawk@>=3.1.0 <3.2.0",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@>=2.0.0 <3.0.0"
+                    },
+                    "boom": {
+                      "version": "2.10.0",
+                      "from": "boom@>=2.8.0 <3.0.0"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@>=2.0.0 <3.0.0"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "aws-sign2@>=0.6.0 <0.7.0"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "stringstream@>=0.0.4 <0.1.0"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "combined-stream@>=1.0.5 <1.1.0",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.2 <0.2.0"
+                },
+                "har-validator": {
+                  "version": "2.0.2",
+                  "from": "har-validator@>=2.0.2 <2.1.0",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@>=2.8.1 <3.0.0",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>=1.0.0"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.2",
+                      "from": "is-my-json-valid@>=2.12.2 <3.0.0",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@>=2.0.0 <3.0.0"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "is-property@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "2.0.0",
+                          "from": "jsonpointer@2.0.0"
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "xtend@>=4.0.0 <5.0.0"
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "1.0.0",
+                      "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "1.0.0",
+                          "from": "pinkie@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sass-graph": {
+              "version": "2.0.1",
+              "from": "sass-graph@>=2.0.1 <3.0.0",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.8.0 <4.0.0"
+                },
+                "yargs": {
+                  "version": "3.29.0",
+                  "from": "yargs@>=3.8.0 <4.0.0",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.2.1 <2.0.0"
+                    },
+                    "cliui": {
+                      "version": "3.0.3",
+                      "from": "cliui@>=3.0.3 <4.0.0",
+                      "dependencies": {
+                        "string-width": {
+                          "version": "1.0.1",
+                          "from": "string-width@>=1.0.1 <2.0.0",
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.0.0",
+                              "from": "code-point-at@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.0",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0"
+                            }
+                          }
+                        },
+                        "wrap-ansi": {
+                          "version": "1.0.0",
+                          "from": "wrap-ansi@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.1.1",
+                      "from": "decamelize@>=1.0.0 <2.0.0"
+                    },
+                    "os-locale": {
+                      "version": "1.4.0",
+                      "from": "os-locale@>=1.4.0 <2.0.0",
+                      "dependencies": {
+                        "lcid": {
+                          "version": "1.0.0",
+                          "from": "lcid@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "invert-kv": {
+                              "version": "1.0.0",
+                              "from": "invert-kv@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "window-size": {
+                      "version": "0.1.2",
+                      "from": "window-size@>=0.1.2 <0.2.0"
+                    },
+                    "y18n": {
+                      "version": "3.2.0",
+                      "from": "y18n@>=3.2.0 <4.0.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.0.1",
+          "from": "object-assign@>=4.0.1 <5.0.0"
+        },
+        "through2": {
+          "version": "2.0.0",
+          "from": "through2@>=2.0.0 <3.0.0",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.3",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.3",
+                  "from": "process-nextick-args@>=1.0.0 <1.1.0"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0"
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.2.0",
+          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.3",
+              "from": "source-map@>=0.5.1 <0.6.0"
+            }
+          }
+        }
+      }
+    },
+    "gulp-scss-lint": {
+      "version": "0.1.12",
+      "from": "gulp-scss-lint@>=0.1.6 <0.2.0",
+      "dependencies": {
+        "dargs": {
+          "version": "3.0.1",
+          "from": "dargs@>=3.0.0 <3.1.0"
+        },
+        "event-stream": {
+          "version": "3.2.2",
+          "from": "event-stream@>=3.2.2 <3.3.0",
+          "dependencies": {
+            "through": {
+              "version": "2.3.8",
+              "from": "through@>=2.3.1 <2.4.0"
+            },
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "duplexer@>=0.1.1 <0.2.0"
+            },
+            "from": {
+              "version": "0.1.3",
+              "from": "from@>=0.0.0 <1.0.0"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "map-stream@>=0.1.0 <0.2.0"
+            },
+            "pause-stream": {
+              "version": "0.0.11",
+              "from": "pause-stream@0.0.11"
+            },
+            "split": {
+              "version": "0.3.3",
+              "from": "split@>=0.3.0 <0.4.0"
+            },
+            "stream-combiner": {
+              "version": "0.0.4",
+              "from": "stream-combiner@>=0.0.4 <0.1.0"
+            }
+          }
+        },
+        "sync-exec": {
+          "version": "0.5.0",
+          "from": "sync-exec@>=0.5.0 <0.6.0"
+        },
+        "pretty-data": {
+          "version": "0.40.0",
+          "from": "pretty-data@>=0.40.0 <0.41.0"
+        },
+        "xml2js": {
+          "version": "0.4.13",
+          "from": "xml2js@>=0.4.4 <0.5.0",
+          "dependencies": {
+            "sax": {
+              "version": "1.1.4",
+              "from": "sax@>=0.6.0"
+            },
+            "xmlbuilder": {
+              "version": "3.1.0",
+              "from": "xmlbuilder@>=2.4.6",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.5.0 <4.0.0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-shrinkwrap": {
+      "version": "2.0.1",
+      "from": "gulp-shrinkwrap@>=2.0.1 <3.0.0",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.9.14",
+          "from": "bluebird@2.9.14"
+        },
+        "graceful-fs": {
+          "version": "3.0.6",
+          "from": "graceful-fs@3.0.6"
+        },
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@3.0.4",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@1.0.0"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@1.0.2"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@1.0.0"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@1.0.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@2.0.1"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@1.0.3"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@1.0.3",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@1.1.1"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@4.0.1"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@2.0.1",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@1.1.1"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@1.3.0"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@1.0.11",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@4.0.1"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@3.1.0",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@1.0.0",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@1.0.2"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@1.0.0"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@1.2.1",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@1.1.2",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@3.0.0"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@3.0.0"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@3.0.0"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@3.3.2",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@3.0.0"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@3.0.0"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@3.0.0"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@3.0.4"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@3.0.0"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@3.0.4",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@3.0.0"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@3.0.0"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@3.0.0"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@3.1.0"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.1",
+              "from": "minimist@1.1.1"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@0.1.2",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@1.1.13",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@1.0.1"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@0.10.31"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2.0.1"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@2.0.0"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@0.4.6",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@0.2.0"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.1.0",
+          "from": "lodash@3.1.0"
+        },
+        "npm": {
+          "version": "2.7.0",
+          "from": "npm@2.7.0",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@latest"
+            },
+            "ansi": {
+              "version": "0.3.0",
+              "from": "ansi@latest"
+            },
+            "ansicolors": {
+              "version": "0.3.2",
+              "from": "ansicolors@latest"
+            },
+            "ansistyles": {
+              "version": "0.1.3",
+              "from": "ansistyles@0.1.3"
+            },
+            "archy": {
+              "version": "1.0.0",
+              "from": "archy@>=1.0.0 <2.0.0"
+            },
+            "async-some": {
+              "version": "1.0.1",
+              "from": "async-some@>=1.0.1-0 <2.0.0-0"
+            },
+            "block-stream": {
+              "version": "0.0.7",
+              "from": "block-stream@latest"
+            },
+            "char-spinner": {
+              "version": "1.0.1",
+              "from": "char-spinner@latest"
+            },
+            "child-process-close": {
+              "version": "0.1.1",
+              "from": "child-process-close@"
+            },
+            "chmodr": {
+              "version": "0.1.0",
+              "from": "chmodr@latest"
+            },
+            "chownr": {
+              "version": "0.0.1",
+              "from": "../chownr"
+            },
+            "cmd-shim": {
+              "version": "2.0.1",
+              "from": "cmd-shim@>=2.0.1-0 <3.0.0-0"
+            },
+            "columnify": {
+              "version": "1.4.1",
+              "from": "columnify@>=1.4.1 <1.5.0",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.0 <3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.0",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "wcwidth": {
+                  "version": "1.0.0",
+                  "from": "wcwidth@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "defaults": {
+                      "version": "1.0.0",
+                      "from": "defaults@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "clone": {
+                          "version": "0.1.19",
+                          "from": "clone@>=0.1.5 <0.2.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "config-chain": {
+              "version": "1.1.8",
+              "from": "config-chain@^1.1.8",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.3",
+                  "from": "proto-list@~1.2.1"
+                }
+              }
+            },
+            "dezalgo": {
+              "version": "1.0.1",
+              "from": "dezalgo@latest",
+              "dependencies": {
+                "asap": {
+                  "version": "1.0.0",
+                  "from": "asap@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "editor": {
+              "version": "0.1.0",
+              "from": "editor@latest"
+            },
+            "fs-vacuum": {
+              "version": "1.2.5",
+              "from": "fs-vacuum@~1.2.5"
+            },
+            "fs-write-stream-atomic": {
+              "version": "1.0.2",
+              "from": "fs-write-stream-atomic@>=1.0.2 <1.1.0"
+            },
+            "fstream": {
+              "version": "1.0.4",
+              "from": "fstream@>=1.0.4 <1.1.0"
+            },
+            "fstream-npm": {
+              "version": "1.0.1",
+              "from": "fstream-npm@1.0.1",
+              "dependencies": {
+                "fstream-ignore": {
+                  "version": "1.0.2",
+                  "from": "fstream-ignore@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "github-url-from-git": {
+              "version": "1.4.0",
+              "from": "github-url-from-git@>=1.4.0-0 <2.0.0-0"
+            },
+            "github-url-from-username-repo": {
+              "version": "1.0.2",
+              "from": "github-url-from-username-repo@>=1.0.2-0 <2.0.0-0"
+            },
+            "glob": {
+              "version": "4.4.1",
+              "from": "glob@>=4.4.1 <4.5.0"
+            },
+            "graceful-fs": {
+              "version": "3.0.5",
+              "from": "graceful-fs@>=3.0.5 <3.1.0"
+            },
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <1.1.0"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@latest"
+            },
+            "ini": {
+              "version": "1.3.3",
+              "from": "ini@>=1.3.1 <1.4.0"
+            },
+            "init-package-json": {
+              "version": "1.3.0",
+              "from": "init-package-json@>=1.3.0 <1.4.0",
+              "dependencies": {
+                "promzard": {
+                  "version": "0.2.2",
+                  "from": "promzard@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "lockfile": {
+              "version": "1.0.0",
+              "from": "lockfile@1.0.0"
+            },
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@latest"
+            },
+            "minimatch": {
+              "version": "2.0.1",
+              "from": "minimatch@>=2.0.1 <2.1.0",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.0.1",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.0",
+                      "from": "concat-map@0.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@latest",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8"
+                }
+              }
+            },
+            "node-gyp": {
+              "version": "1.0.2",
+              "from": "node-gyp@>=1.0.2 <1.1.0",
+              "dependencies": {
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "minimatch@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "from": "nopt@latest"
+            },
+            "normalize-git-url": {
+              "version": "1.0.0",
+              "from": "normalize-git-url@>=1.0.0 <1.1.0"
+            },
+            "normalize-package-data": {
+              "version": "1.0.3",
+              "from": "normalize-package-data@>=1.0.3 <1.1.0"
+            },
+            "npm-cache-filename": {
+              "version": "1.0.1",
+              "from": "npm-cache-filename@latest"
+            },
+            "npm-install-checks": {
+              "version": "1.0.5",
+              "from": "npm-install-checks@>=1.0.5 <1.1.0"
+            },
+            "npm-package-arg": {
+              "version": "2.1.3",
+              "from": "npm-package-arg@~2.1.3"
+            },
+            "npm-registry-client": {
+              "version": "6.1.1",
+              "from": "npm-registry-client@>=6.1.1 <6.2.0",
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.4.7",
+                  "from": "concat-stream@>=1.4.6 <2.0.0",
+                  "dependencies": {
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "npm-package-arg": {
+                  "version": "3.1.0",
+                  "from": "npm-package-arg@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "hosted-git-info": {
+                      "version": "1.5.3",
+                      "from": "hosted-git-info@>=1.5.3 <2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "npm-user-validate": {
+              "version": "0.1.1",
+              "from": "npm-user-validate@>=0.1.1 <0.2.0"
+            },
+            "npmlog": {
+              "version": "0.1.1",
+              "from": "npmlog@latest"
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.3.1 <2.0.0"
+            },
+            "opener": {
+              "version": "1.4.0",
+              "from": "opener@>=1.4.0 <1.5.0"
+            },
+            "osenv": {
+              "version": "0.1.0",
+              "from": "osenv@~0.1.0"
+            },
+            "path-is-inside": {
+              "version": "1.0.1",
+              "from": "path-is-inside@1.0.1"
+            },
+            "read": {
+              "version": "1.0.5",
+              "from": "read@latest",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "mute-stream@~0.0.4"
+                }
+              }
+            },
+            "read-installed": {
+              "version": "3.1.5",
+              "from": "read-installed@>=3.1.5 <3.2.0",
+              "dependencies": {
+                "debuglog": {
+                  "version": "1.0.1",
+                  "from": "debuglog@>=1.0.1 <2.0.0"
+                },
+                "readdir-scoped-modules": {
+                  "version": "1.0.1",
+                  "from": "readdir-scoped-modules@>=1.0.0 <2.0.0"
+                },
+                "util-extend": {
+                  "version": "1.0.1",
+                  "from": "util-extend@>=1.0.1 <2.0.0"
+                }
+              }
+            },
+            "read-package-json": {
+              "version": "1.3.1",
+              "from": "read-package-json@1.3.1"
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33 <1.1.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                }
+              }
+            },
+            "realize-package-specifier": {
+              "version": "1.3.0",
+              "from": "realize-package-specifier@~1.3.0"
+            },
+            "request": {
+              "version": "2.53.0",
+              "from": "request@>=2.53.0 <2.54.0",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0"
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "from": "caseless@>=0.9.0 <0.10.0"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0"
+                },
+                "mime-types": {
+                  "version": "2.0.8",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.6.1",
+                      "from": "mime-db@>=1.6.0 <1.7.0"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.2",
+                  "from": "node-uuid@>=1.4.0 <1.5.0"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@>=2.3.1 <2.4.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "from": "oauth-sign@>=0.6.0 <0.7.0"
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.11.0",
+                      "from": "hoek@>=2.0.0 <3.0.0"
+                    },
+                    "boom": {
+                      "version": "2.6.1",
+                      "from": "boom@>=2.0.0 <3.0.0"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "from": "cryptiles@>=2.0.0 <3.0.0"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.1",
+                  "from": "isstream@>=0.1.1 <0.2.0"
+                }
+              }
+            },
+            "retry": {
+              "version": "0.6.1",
+              "from": "retry@>=0.6.1 <0.7.0"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@latest"
+            },
+            "semver": {
+              "version": "4.3.1",
+              "from": "semver@>=4.3.1 <4.4.0"
+            },
+            "sha": {
+              "version": "1.3.0",
+              "from": "sha@>=1.3.0 <1.4.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    }
+                  }
+                }
+              }
+            },
+            "slide": {
+              "version": "1.1.6",
+              "from": "slide@>=1.1.6 <1.2.0"
+            },
+            "sorted-object": {
+              "version": "1.0.0",
+              "from": "sorted-object@"
+            },
+            "tar": {
+              "version": "1.0.3",
+              "from": "tar@>=1.0.3 <1.1.0"
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "from": "text-table@~0.2.0"
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "from": "uid-number@>=0.0.6 <0.1.0"
+            },
+            "umask": {
+              "version": "1.1.0",
+              "from": "umask@>=1.1.0 <1.2.0"
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.9 <1.1.0"
+            },
+            "wrappy": {
+              "version": "1.0.1",
+              "from": "wrappy@1.0.1"
+            },
+            "write-file-atomic": {
+              "version": "1.1.0",
+              "from": "write-file-atomic@>=1.1.0 <2.0.0"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@0.6.3",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@1.0.33",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0"
+            }
+          }
+        }
+      }
+    },
+    "gulp-svg-symbols": {
+      "version": "0.3.2",
+      "from": "gulp-svg-symbols@>=0.3.1 <0.4.0",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.10.2",
+          "from": "bluebird@>=2.3.2 <3.0.0"
+        },
+        "consolidate": {
+          "version": "0.13.1",
+          "from": "consolidate@>=0.13.1 <0.14.0"
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.10.1 <4.0.0"
+        },
+        "mathjs": {
+          "version": "2.4.1",
+          "from": "mathjs@>=2.3.0 <3.0.0",
+          "dependencies": {
+            "decimal.js": {
+              "version": "4.0.3",
+              "from": "decimal.js@>=4.0.2 <5.0.0"
+            },
+            "fraction.js": {
+              "version": "3.0.0",
+              "from": "fraction.js@>=3.0.0 <4.0.0"
+            },
+            "tiny-emitter": {
+              "version": "1.0.1",
+              "from": "tiny-emitter@>=1.0.0 <2.0.0"
+            },
+            "typed-function": {
+              "version": "0.10.3",
+              "from": "typed-function@>=0.10.3 <0.11.0"
+            }
+          }
+        },
+        "svgo": {
+          "version": "0.5.6",
+          "from": "svgo@>=0.5.6 <0.6.0",
+          "dependencies": {
+            "sax": {
+              "version": "1.1.4",
+              "from": "sax@>=1.1.1 <1.2.0"
+            },
+            "coa": {
+              "version": "1.0.1",
+              "from": "coa@>=1.0.1 <1.1.0",
+              "dependencies": {
+                "q": {
+                  "version": "1.4.1",
+                  "from": "q@>=1.1.2 <2.0.0"
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.3.1",
+              "from": "js-yaml@>=3.3.1 <3.4.0",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.3",
+                  "from": "argparse@>=1.0.2 <1.1.0",
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "esprima@>=2.2.0 <2.3.0"
+                }
+              }
+            },
+            "colors": {
+              "version": "1.1.2",
+              "from": "colors@>=1.1.2 <1.2.0"
+            },
+            "whet.extend": {
+              "version": "0.9.9",
+              "from": "whet.extend@>=0.9.9 <0.10.0"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "2.0.0",
+          "from": "through2@>=2.0.0 <3.0.0",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.3",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.3",
+                  "from": "process-nextick-args@>=1.0.0 <1.1.0"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0"
+            }
+          }
+        }
+      }
+    },
+    "gulp-symlink": {
+      "version": "2.1.3",
+      "from": "gulp-symlink@>=2.1.0 <3.0.0",
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8"
+            }
+          }
+        },
+        "through2": {
+          "version": "2.0.0",
+          "from": "through2@>=2.0.0 <2.1.0",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.3",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.3",
+                  "from": "process-nextick-args@>=1.0.0 <1.1.0"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0"
+            }
+          }
+        },
+        "async": {
+          "version": "1.4.2",
+          "from": "async@>=1.4.0 <1.5.0"
+        }
+      }
+    },
+    "gulp-tag-version": {
+      "version": "1.3.0",
+      "from": "gulp-tag-version@>=1.2.1 <2.0.0",
+      "dependencies": {
+        "map-stream": {
+          "version": "0.1.0",
+          "from": "map-stream@>=0.1.0 <0.2.0"
+        },
+        "gulp-util": {
+          "version": "2.2.20",
+          "from": "gulp-util@>=2.2.14 <2.3.0",
+          "dependencies": {
+            "chalk": {
+              "version": "0.5.1",
+              "from": "chalk@>=0.5.0 <0.6.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0"
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@>=1.0.7-1.2.3 <2.0.0",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "5.0.0",
+                  "from": "get-stdin@*"
+                },
+                "meow": {
+                  "version": "3.4.2",
+                  "from": "meow@*",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "from": "camelcase@>=1.0.1 <2.0.0"
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "loud-rejection": {
+                      "version": "1.0.0",
+                      "from": "loud-rejection@>=1.0.0 <2.0.0"
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@>=1.1.3 <2.0.0"
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.4",
+                      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.4",
+                          "from": "hosted-git-info@>=2.0.2 <3.0.0"
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.0",
+                              "from": "builtin-modules@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "5.0.3",
+                          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0"
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.2",
+                              "from": "spdx-correct@>=1.0.0 <1.1.0",
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.1.0",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0"
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.0",
+                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                              "dependencies": {
+                                "spdx-exceptions": {
+                                  "version": "1.0.3",
+                                  "from": "spdx-exceptions@>=1.0.0 <2.0.0"
+                                },
+                                "spdx-license-ids": {
+                                  "version": "1.1.0",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "4.0.1",
+                      "from": "object-assign@>=4.0.1 <5.0.0"
+                    },
+                    "read-pkg-up": {
+                      "version": "1.0.1",
+                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                      "dependencies": {
+                        "find-up": {
+                          "version": "1.0.0",
+                          "from": "find-up@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "path-exists": {
+                              "version": "2.0.0",
+                              "from": "path-exists@>=2.0.0 <3.0.0"
+                            },
+                            "pinkie-promise": {
+                              "version": "1.0.0",
+                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "read-pkg": {
+                          "version": "1.1.0",
+                          "from": "read-pkg@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "load-json-file": {
+                              "version": "1.0.1",
+                              "from": "load-json-file@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.2",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0"
+                                },
+                                "parse-json": {
+                                  "version": "2.2.0",
+                                  "from": "parse-json@>=2.2.0 <3.0.0",
+                                  "dependencies": {
+                                    "error-ex": {
+                                      "version": "1.2.0",
+                                      "from": "error-ex@>=1.2.0 <2.0.0"
+                                    }
+                                  }
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "from": "pify@>=2.0.0 <3.0.0"
+                                },
+                                "pinkie-promise": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "1.0.0",
+                                      "from": "pinkie@>=1.0.0 <2.0.0"
+                                    }
+                                  }
+                                },
+                                "strip-bom": {
+                                  "version": "2.0.0",
+                                  "from": "strip-bom@>=2.0.0 <3.0.0",
+                                  "dependencies": {
+                                    "is-utf8": {
+                                      "version": "0.2.0",
+                                      "from": "is-utf8@>=0.2.0 <0.3.0"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "path-type": {
+                              "version": "1.0.0",
+                              "from": "path-type@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.2",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0"
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "from": "pify@>=2.0.0 <3.0.0"
+                                },
+                                "pinkie-promise": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "1.0.0",
+                                      "from": "pinkie@>=1.0.0 <2.0.0"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "redent": {
+                      "version": "1.0.0",
+                      "from": "redent@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "indent-string": {
+                          "version": "2.1.0",
+                          "from": "indent-string@>=2.1.0 <3.0.0",
+                          "dependencies": {
+                            "repeating": {
+                              "version": "2.0.0",
+                              "from": "repeating@>=2.0.0 <3.0.0",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-indent": {
+                          "version": "1.0.1",
+                          "from": "strip-indent@>=1.0.1 <2.0.0",
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "get-stdin@>=4.0.1 <5.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "trim-newlines": {
+                      "version": "1.0.0",
+                      "from": "trim-newlines@>=1.0.0 <2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reinterpolate": {
+              "version": "2.4.1",
+              "from": "lodash._reinterpolate@>=2.4.1 <3.0.0"
+            },
+            "lodash.template": {
+              "version": "2.4.1",
+              "from": "lodash.template@>=2.4.1 <3.0.0",
+              "dependencies": {
+                "lodash.defaults": {
+                  "version": "2.4.1",
+                  "from": "lodash.defaults@>=2.4.1 <2.5.0",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@>=2.4.1 <2.5.0"
+                    }
+                  }
+                },
+                "lodash.escape": {
+                  "version": "2.4.1",
+                  "from": "lodash.escape@>=2.4.1 <2.5.0",
+                  "dependencies": {
+                    "lodash._escapehtmlchar": {
+                      "version": "2.4.1",
+                      "from": "lodash._escapehtmlchar@>=2.4.1 <2.5.0",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0"
+                        }
+                      }
+                    },
+                    "lodash._reunescapedhtml": {
+                      "version": "2.4.1",
+                      "from": "lodash._reunescapedhtml@>=2.4.1 <2.5.0",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._escapestringchar": {
+                  "version": "2.4.1",
+                  "from": "lodash._escapestringchar@>=2.4.1 <2.5.0"
+                },
+                "lodash.keys": {
+                  "version": "2.4.1",
+                  "from": "lodash.keys@>=2.4.1 <2.5.0",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@>=2.4.1 <2.5.0"
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0"
+                        }
+                      }
+                    },
+                    "lodash._shimkeys": {
+                      "version": "2.4.1",
+                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "2.4.1",
+                  "from": "lodash.templatesettings@>=2.4.1 <2.5.0"
+                },
+                "lodash.values": {
+                  "version": "2.4.1",
+                  "from": "lodash.values@>=2.4.1 <2.5.0"
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.2.0",
+              "from": "minimist@>=0.2.0 <0.3.0"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@>=0.1.0 <0.2.0",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "through2": {
+              "version": "0.5.1",
+              "from": "through2@>=0.5.0 <0.6.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "3.0.0",
+                  "from": "xtend@>=3.0.0 <3.1.0"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.2.3",
+              "from": "vinyl@>=0.2.1 <0.3.0",
+              "dependencies": {
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.1.0"
+                }
+              }
+            }
+          }
+        },
+        "gulp-git": {
+          "version": "0.3.6",
+          "from": "gulp-git@>=0.3.6 <0.4.0",
+          "dependencies": {
+            "any-shell-escape": {
+              "version": "0.1.1",
+              "from": "any-shell-escape@>=0.1.1 <0.2.0"
+            },
+            "through2": {
+              "version": "0.4.2",
+              "from": "through2@>=0.4.1 <0.5.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@1.0.33",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "2.1.2",
+                  "from": "xtend@>=2.1.1 <2.2.0",
+                  "dependencies": {
+                    "object-keys": {
+                      "version": "0.4.0",
+                      "from": "object-keys@>=0.4.0 <0.5.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.7",
+      "from": "gulp-util@>=3.0.0 <4.0.0",
+      "dependencies": {
+        "array-differ": {
+          "version": "1.0.0",
+          "from": "array-differ@>=1.0.0 <2.0.0"
+        },
+        "array-uniq": {
+          "version": "1.0.2",
+          "from": "array-uniq@>=1.0.2 <2.0.0"
+        },
+        "beeper": {
+          "version": "1.1.0",
+          "from": "beeper@>=1.0.0 <2.0.0"
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0"
+            }
+          }
+        },
+        "dateformat": {
+          "version": "1.0.11",
+          "from": "dateformat@>=1.0.11 <2.0.0",
+          "dependencies": {
+            "get-stdin": {
+              "version": "5.0.0",
+              "from": "get-stdin@*"
+            },
+            "meow": {
+              "version": "3.4.2",
+              "from": "meow@*",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "loud-rejection": {
+                  "version": "1.0.0",
+                  "from": "loud-rejection@>=1.0.0 <2.0.0"
+                },
+                "normalize-package-data": {
+                  "version": "2.3.4",
+                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                  "dependencies": {
+                    "hosted-git-info": {
+                      "version": "2.1.4",
+                      "from": "hosted-git-info@>=2.0.2 <3.0.0"
+                    },
+                    "is-builtin-module": {
+                      "version": "1.0.0",
+                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "builtin-modules": {
+                          "version": "1.1.0",
+                          "from": "builtin-modules@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "5.0.3",
+                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0"
+                    },
+                    "validate-npm-package-license": {
+                      "version": "3.0.1",
+                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                      "dependencies": {
+                        "spdx-correct": {
+                          "version": "1.0.2",
+                          "from": "spdx-correct@>=1.0.0 <1.1.0",
+                          "dependencies": {
+                            "spdx-license-ids": {
+                              "version": "1.1.0",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0"
+                            }
+                          }
+                        },
+                        "spdx-expression-parse": {
+                          "version": "1.0.0",
+                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                          "dependencies": {
+                            "spdx-exceptions": {
+                              "version": "1.0.3",
+                              "from": "spdx-exceptions@>=1.0.0 <2.0.0"
+                            },
+                            "spdx-license-ids": {
+                              "version": "1.1.0",
+                              "from": "spdx-license-ids@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "4.0.1",
+                  "from": "object-assign@>=4.0.1 <5.0.0"
+                },
+                "read-pkg-up": {
+                  "version": "1.0.1",
+                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                  "dependencies": {
+                    "find-up": {
+                      "version": "1.0.0",
+                      "from": "find-up@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "path-exists": {
+                          "version": "2.0.0",
+                          "from": "path-exists@>=2.0.0 <3.0.0"
+                        },
+                        "pinkie-promise": {
+                          "version": "1.0.0",
+                          "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "1.0.0",
+                              "from": "pinkie@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "read-pkg": {
+                      "version": "1.1.0",
+                      "from": "read-pkg@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "load-json-file": {
+                          "version": "1.0.1",
+                          "from": "load-json-file@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.2",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0"
+                            },
+                            "parse-json": {
+                              "version": "2.2.0",
+                              "from": "parse-json@>=2.2.0 <3.0.0",
+                              "dependencies": {
+                                "error-ex": {
+                                  "version": "1.2.0",
+                                  "from": "error-ex@>=1.2.0 <2.0.0"
+                                }
+                              }
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "from": "pify@>=2.0.0 <3.0.0"
+                            },
+                            "pinkie-promise": {
+                              "version": "1.0.0",
+                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            },
+                            "strip-bom": {
+                              "version": "2.0.0",
+                              "from": "strip-bom@>=2.0.0 <3.0.0",
+                              "dependencies": {
+                                "is-utf8": {
+                                  "version": "0.2.0",
+                                  "from": "is-utf8@>=0.2.0 <0.3.0"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-type": {
+                          "version": "1.0.0",
+                          "from": "path-type@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.2",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0"
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "from": "pify@>=2.0.0 <3.0.0"
+                            },
+                            "pinkie-promise": {
+                              "version": "1.0.0",
+                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "redent": {
+                  "version": "1.0.0",
+                  "from": "redent@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "indent-string": {
+                      "version": "2.1.0",
+                      "from": "indent-string@>=2.1.0 <3.0.0",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "2.0.0",
+                          "from": "repeating@>=2.0.0 <3.0.0",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-indent": {
+                      "version": "1.0.1",
+                      "from": "strip-indent@>=1.0.1 <2.0.0",
+                      "dependencies": {
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "get-stdin@>=4.0.1 <5.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "trim-newlines": {
+                  "version": "1.0.0",
+                  "from": "trim-newlines@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "fancy-log": {
+          "version": "1.1.0",
+          "from": "fancy-log@>=1.1.0 <2.0.0"
+        },
+        "gulplog": {
+          "version": "1.0.0",
+          "from": "gulplog@>=1.0.0 <2.0.0",
+          "dependencies": {
+            "glogg": {
+              "version": "1.0.0",
+              "from": "glogg@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "sparkles": {
+                  "version": "1.0.0",
+                  "from": "sparkles@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "has-gulplog": {
+          "version": "0.1.0",
+          "from": "has-gulplog@>=0.1.0 <0.2.0",
+          "dependencies": {
+            "sparkles": {
+              "version": "1.0.0",
+              "from": "sparkles@>=1.0.0 <2.0.0"
+            }
+          }
+        },
+        "lodash._reescape": {
+          "version": "3.0.0",
+          "from": "lodash._reescape@>=3.0.0 <4.0.0"
+        },
+        "lodash._reevaluate": {
+          "version": "3.0.0",
+          "from": "lodash._reevaluate@>=3.0.0 <4.0.0"
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "from": "lodash._reinterpolate@>=3.0.0 <4.0.0"
+        },
+        "lodash.template": {
+          "version": "3.6.2",
+          "from": "lodash.template@>=3.0.0 <4.0.0",
+          "dependencies": {
+            "lodash._basecopy": {
+              "version": "3.0.1",
+              "from": "lodash._basecopy@>=3.0.0 <4.0.0"
+            },
+            "lodash._basetostring": {
+              "version": "3.0.1",
+              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
+            },
+            "lodash._basevalues": {
+              "version": "3.0.0",
+              "from": "lodash._basevalues@>=3.0.0 <4.0.0"
+            },
+            "lodash._isiterateecall": {
+              "version": "3.0.9",
+              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0"
+            },
+            "lodash.escape": {
+              "version": "3.0.0",
+              "from": "lodash.escape@>=3.0.0 <4.0.0"
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "from": "lodash._getnative@>=3.0.0 <4.0.0"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0"
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0"
+            },
+            "lodash.templatesettings": {
+              "version": "3.1.0",
+              "from": "lodash.templatesettings@>=3.0.0 <4.0.0"
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.1.0 <2.0.0"
+        },
+        "multipipe": {
+          "version": "0.1.2",
+          "from": "multipipe@>=0.1.2 <0.2.0",
+          "dependencies": {
+            "duplexer2": {
+              "version": "0.0.2",
+              "from": "duplexer2@0.0.2",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "from": "object-assign@>=3.0.0 <4.0.0"
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "from": "replace-ext@0.0.1"
+        },
+        "through2": {
+          "version": "2.0.0",
+          "from": "through2@>=2.0.0 <3.0.0",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.3",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.3",
+                  "from": "process-nextick-args@>=1.0.0 <1.1.0"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0"
+            }
+          }
+        },
+        "vinyl": {
+          "version": "0.5.3",
+          "from": "vinyl@>=0.5.0 <0.6.0",
+          "dependencies": {
+            "clone": {
+              "version": "1.0.2",
+              "from": "clone@>=1.0.0 <2.0.0"
+            },
+            "clone-stats": {
+              "version": "0.0.1",
+              "from": "clone-stats@>=0.0.1 <0.0.2"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,15 +5,16 @@
   "private": false,
   "main": "dist/js/lego.min.js",
   "dependencies": {
+    "gulp-sass": "^2.0.2"
+  },
+  "devDependencies": {
     "browser-sync": "^2.9.8",
-    "gulp-sass": "^2.0.2",
     "gulp": "^3.8.8",
     "gulp-bump": "^0.3.1",
     "gulp-filter": "^2.0.2",
     "gulp-git": "^1.2.4",
     "gulp-notify": "^2.2.0",
     "gulp-scss-lint": "^0.1.6",
-    "gulp-shrinkwrap": "^2.0.1",
     "gulp-svg-symbols": "^0.3.1",
     "gulp-symlink": "^2.1.0",
     "gulp-tag-version": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -6,15 +6,14 @@
   "main": "dist/js/lego.min.js",
   "dependencies": {
     "browser-sync": "^2.9.8",
-    "gulp-sass": "^2.0.2"
-  },
-  "devDependencies": {
+    "gulp-sass": "^2.0.2",
     "gulp": "^3.8.8",
     "gulp-bump": "^0.3.1",
     "gulp-filter": "^2.0.2",
     "gulp-git": "^1.2.4",
     "gulp-notify": "^2.2.0",
     "gulp-scss-lint": "^0.1.6",
+    "gulp-shrinkwrap": "^2.0.1",
     "gulp-svg-symbols": "^0.3.1",
     "gulp-symlink": "^2.1.0",
     "gulp-tag-version": "^1.2.1",


### PR DESCRIPTION
Here are the steps I took. This is a one-time thing, developers cloning the repo do not need to do anything special.

**package.json**

- `gulp-sass` is the only entry in “dependencies”
- all others gulp packages are listed in “devDependencies”

**at oui root** 

- remove `node_modules` or from a fresh clone run `npm install` 
- edit into `node_modules/gulp-sass/package.json` by changing `"node-sass": "^3.4.1"` to version `"3.3.3"`
- in `node_modules/gulp-sass/` directory run `npm install --production` to reinstall `gulp-sass` "dependencies" (and not the "devDependencies") to install the earlier version of `node-sass`
- cd back to `oui` root and run `npm shrinkwrap`
- this creates `npm-shrinkwrap.json` file at the root. It is generated by reading through all "dependencies" and, in this case, writing out only the `gulp-sass` dependencies. 
- commited `npm-shrinkwrap.json` into git 

To test, remove repo’s `node_modules` and run `npm install`. You can confirm it worked if `node_modules/gulp-sass/node-sass/package.json` installed version 3.3.3.

Future package installation should be done with `npm install [package-name] --dev` so that entries for them will show up in `"devDependencies"` and will not trigger a mismatch between `package.json` and `npm-shrinkwrap.json`. 

https://docs.npmjs.com/cli/shrinkwrap