### PR TITLE
Icon align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 ## [Unreleased][Unreleased]
 
 ### Added
+- [Patch] Adding `.icon--text-align` class to allow inline icons to visually align with the text. E.g., help icons.
+
 ### Changed
 - [Patch] Simplifying CSS in `_select.scss` to remove IE hacks.
 - [Patch] Removed IE10+ mixin in `partials/elements/_mixins.scss` to remove IE hacks. Not being used.

--- a/src/core/partials/objects/_icons.scss
+++ b/src/core/partials/objects/_icons.scss
@@ -76,10 +76,15 @@
     width: 32px;
     height: 32px;
   }
-  // This is a vertical alignment fix when used to the right of `.#{$namespace}icon`.
 
+  // This is a vertical alignment fix when used to the right of `.#{$namespace}icon`.
   + [class^="#{$namespace}-arrow-inline"] {
     vertical-align: super;
+  }
+
+  &--text-align {
+    position: relative;
+    top: 2px; // This moves the inline icon down so it is visually aligned with the text.
   }
 }
 


### PR DESCRIPTION
Adding `.icon--text-align` class to allow inline icons to visually align with the text. E.g., help icons.

Before:
![screen shot 2015-12-09 at 3 08 57 pm](https://cloud.githubusercontent.com/assets/1171072/11701830/d37115c6-9e86-11e5-923a-1028aa1cded2.png)

After:
![screen shot 2015-12-09 at 3 09 11 pm](https://cloud.githubusercontent.com/assets/1171072/11701831/d373bf24-9e86-11e5-8e84-7b05425c82a0.png)

@danoc @kwalker3690 
