### PR TITLE
Rename an incorrect width class referenced within a comment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 - [Patch] Fix incorrect width in width--75 sizing class (#244)
 - [Patch] Removed extraneous comment (#234)
 - [Patch] Tiny documentation fixes. (#234)
+- [Patch] Rename an incorrect width class referenced within a comment. (#256)
 
 ## [9.0.0][9.0.0] - 2016-01-19
 ### Added

--- a/src/oui/partials/base/_form.scss
+++ b/src/oui/partials/base/_form.scss
@@ -24,7 +24,7 @@
 ///         </li>
 ///         <li class="#{$namespace}form-field__item">
 ///           <label class="#{$namespace}label">Add/Remove Row</label>
-///           <table class="#{$namespace}table #{$namespace}table--add-row width-1">
+///           <table class="#{$namespace}table #{$namespace}table--add-row width--1-1">
 ///             <tr>
 ///               <td><input type="text" class="#{$namespace}text-input"></td>
 ///               <td><input type="text" class="#{$namespace}text-input"></td>


### PR DESCRIPTION
Fixes #256.

cc: @tomgenoni 