### PR TITLE
Add prefix to code examples for `_code.scss`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 - [Patch] Add step at end of CONTRIBUTING to include merging `master` back into `devel`. (#273)
 - [Patch] Adding CSS for nested buttons (like in dropdows) in `button-group` so rounded corners work as expected (#137).
 - [Patch] Re-add missing variable `pkg` in `deploy.js`. (#210)
+- [Patch] Add prefix to code examples for `_code.scss`. (#286)
 - [Patch] Fix deploy gulpfile to include merging `master` back into `devel`. (#209)
 - [Patch] Remove comment that didn't have any content. (#257)
 - [Patch] Fix typo in license.

--- a/src/oui/partials/base/_code.scss
+++ b/src/oui/partials/base/_code.scss
@@ -3,9 +3,9 @@
 /// @description Monospace code snippets, both inline and multiline.
 /// @group Base
 /// @example[html] Inline code
-///   Text can have <code class="code">code snippets</code> in a sentence.
+///   Text can have <code class="#{$namespace}code">code snippets</code> in a sentence.
 /// @example[html] Multiline code
-///   <pre class="pre"><code><p>A multiline example
+///   <pre class="#{$namespace}pre"><code><p>A multiline example
 ///     of code.</p></code></pre>
 ////
 


### PR DESCRIPTION
Fixes #286.