### PR TITLE
Rename "base" directory to "elements" and move in relevant files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 - [Release] Move functions, mixins, and Sass-y things to a `partials/sass/` directory. This change requires updating the main SCSS file that imports the OUI partials and variables. (#259)
 - [Release] Rename `_rules.scss` to `_horizontal-rules.scss`. (#271)
 - [Release] Move `_array.scss`, `_button-group.scss`, `_button-row.scss`, `_clearfix.scss`, `_flexbox.scss`, `_grid.scss`, `island.scss`, and `_matrix.scss` into a `layout/` directory. (#258)
+- [Release] Rename `base/` to `elements/` and move `_buttons.scss` and `_horizontal-rules.scss` into it. (#268)
 - [Patch] Clean up `package.json`.
 - [Patch] Move the `.no-border` classes from layout trumps to border trumps. (#228)
 

--- a/src/oui/_oui-partials.scss
+++ b/src/oui/_oui-partials.scss
@@ -14,19 +14,21 @@
 /// Base
 /// @description Baseline rules.
 
-@import 'partials/base/reset';
-@import 'partials/base/main';
+@import 'partials/elements/reset';
+@import 'partials/elements/main';
 
-@import 'partials/base/blockquote';
-@import 'partials/base/code';
-@import 'partials/base/fonts';
-@import 'partials/base/form';
-@import 'partials/base/images';
-@import 'partials/base/links';
-@import 'partials/base/lists';
-@import 'partials/base/select';
-@import 'partials/base/tables';
-@import 'partials/base/text';
+@import 'partials/elements/blockquote';
+@import 'partials/elements/buttons';
+@import 'partials/elements/code';
+@import 'partials/elements/fonts';
+@import 'partials/elements/form';
+@import 'partials/elements/horizontal-rules';
+@import 'partials/elements/images';
+@import 'partials/elements/links';
+@import 'partials/elements/lists';
+@import 'partials/elements/select';
+@import 'partials/elements/tables';
+@import 'partials/elements/text';
 
 /// Layout
 /// @description Files containing classes that help lay out elements
@@ -46,7 +48,6 @@
 @import 'partials/components/arrows-inline';
 @import 'partials/components/media';
 @import 'partials/components/nav';
-@import 'partials/components/horizontal-rules';
 @import 'partials/components/stats';
 
 /// Objects
@@ -56,7 +57,6 @@
 @import 'partials/objects/accordion';
 @import 'partials/objects/attention';
 @import 'partials/objects/block-list';
-@import 'partials/objects/buttons';
 @import 'partials/objects/dialog';
 @import 'partials/objects/disclose';
 @import 'partials/objects/dropdown';

--- a/src/oui/partials/elements/_blockquote.scss
+++ b/src/oui/partials/elements/_blockquote.scss
@@ -1,7 +1,7 @@
 ////
 /// Blockquotes
 /// @description For quoting blocks of content.
-/// @group Base
+/// @group Elements
 /// @example[html]
 ///   <blockquote>
 ///     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>

--- a/src/oui/partials/elements/_buttons.scss
+++ b/src/oui/partials/elements/_buttons.scss
@@ -2,7 +2,7 @@
 /// Buttons
 /// @description These are the default button styles. `!important` is used on
 /// colors to override default colors.
-/// @group Objects
+/// @group Elements
 /// @example[html] Button colors
 ///   <button class="#{$namespace}button">Button</button>
 ///   <button class="#{$namespace}button #{$namespace}button--highlight">Button</button>

--- a/src/oui/partials/elements/_code.scss
+++ b/src/oui/partials/elements/_code.scss
@@ -1,7 +1,7 @@
 ////
 /// Code
 /// @description Monospace code snippets, both inline and multiline.
-/// @group Base
+/// @group Elements
 /// @example[html] Inline code
 ///   Text can have <code class="#{$namespace}code">code snippets</code> in a sentence.
 /// @example[html] Multiline code

--- a/src/oui/partials/elements/_fonts.scss
+++ b/src/oui/partials/elements/_fonts.scss
@@ -5,7 +5,7 @@
 /// Font Support:
 /// - woff2: Chrome 26+, Opera 23+
 /// - woff: Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+
-/// @group Base
+/// @group Elements
 /// @example[scss] Load fonts by including in theme's variable file.
 ///   $include-fonts:(
 ///     weights: 300 400 500,

--- a/src/oui/partials/elements/_form.scss
+++ b/src/oui/partials/elements/_form.scss
@@ -1,7 +1,7 @@
 ////
 /// Forms
 /// @description Form variations.
-/// @group Base
+/// @group Elements
 /// @example[html]
 ///   <form>
 ///     <div class="#{$namespace}form__header">

--- a/src/oui/partials/elements/_horizontal-rules.scss
+++ b/src/oui/partials/elements/_horizontal-rules.scss
@@ -2,7 +2,7 @@
 /// Horizontal rules
 /// @description Adds styling to an `hr`. Use this between blocks of text or
 /// other elements to provide separation.
-/// @group Components
+/// @group Elements
 /// @example[html] Horizontal rule
 ///   <hr class="#{$namespace}rule">
 /// @example[html] Dotted horizontal rule

--- a/src/oui/partials/elements/_images.scss
+++ b/src/oui/partials/elements/_images.scss
@@ -1,6 +1,6 @@
 ////
 /// Images
-/// @group Base
+/// @group Elements
 ////
 
 img {

--- a/src/oui/partials/elements/_links.scss
+++ b/src/oui/partials/elements/_links.scss
@@ -2,7 +2,7 @@
 /// Links
 /// @description Links will use the `map-fetch($color, link, base)`. You can
 /// also apply a `.link` class to an element to give it the same styles.
-/// @group Base
+/// @group Elements
 /// @example[html]
 ///   Text can have <span class="link">link color</span> when not a HTML anchor.
 /// @example[html]

--- a/src/oui/partials/elements/_lists.scss
+++ b/src/oui/partials/elements/_lists.scss
@@ -2,7 +2,7 @@
 /// Lists
 /// @description We provide classes to add bullets/numbers since we most
 /// commonly use `ol/ul` without the default styling.
-/// @group Base
+/// @group Elements
 /// @example[html]
 ///   <ul class="#{$namespace}list #{$namespace}list--bullet">
 ///     <li>item one</li>

--- a/src/oui/partials/elements/_main.scss
+++ b/src/oui/partials/elements/_main.scss
@@ -1,7 +1,7 @@
 ////
 /// Main
 /// @description High level defaults establishing `font` and `color`.
-/// @group Base
+/// @group Elements
 /// @advanced
 ////
 

--- a/src/oui/partials/elements/_reset.scss
+++ b/src/oui/partials/elements/_reset.scss
@@ -1,7 +1,7 @@
 ////
 /// Reset
 /// @description Using inuit.css reset.
-/// @group Base
+/// @group Elements
 /// @advanced
 ////
 

--- a/src/oui/partials/elements/_select.scss
+++ b/src/oui/partials/elements/_select.scss
@@ -2,6 +2,7 @@
 /// Select
 /// @description Custom `select` elements for Chrome/Safari/Firefox. It
 /// partially changes `select` elements in IE.
+/// @group Elements
 ////
 
 .#{$namespace}select {

--- a/src/oui/partials/elements/_tables.scss
+++ b/src/oui/partials/elements/_tables.scss
@@ -2,7 +2,7 @@
 /// Tables
 /// @description Tables will often require heavier use of helper classes than
 /// normal.
-/// @group Base
+/// @group Elements
 /// @example[html] Basic table
 ///   <table class="#{$namespace}table">
 ///     <thead>

--- a/src/oui/partials/elements/_text.scss
+++ b/src/oui/partials/elements/_text.scss
@@ -1,7 +1,7 @@
 ////
 /// Text
 /// @description Special type design treatments.
-/// @group Base
+/// @group Elements
 ////
 
 /// Editiable


### PR DESCRIPTION
This fixes #268.

Read the ticket for context and a complete list of changes. I decided to leave `_main.scss` or `_fonts.scss` since I couldn't think of a good place for them I'll make a ticket to move those somewhere more logical once this is merged.

cc: @tomgenoni 