### PR TITLE
Add tests for code sample

### DIFF
--- a/src/components/Code/index.js
+++ b/src/components/Code/index.js
@@ -15,12 +15,11 @@ let blockCode = (children) => {
 };
 
 const Code = ({ children, type }) => {
-  return (
-    <div>
-      { type === 'block' ? blockCode(children) : null }
-      { type === 'inline' ? inlineCode(children) : null }
-    </div>
-  );
+  if (type === 'inline') {
+    return inlineCode(children);
+  }
+
+  return blockCode(children);
 };
 
 Code.propTypes = {

--- a/src/components/Code/tests/index.js
+++ b/src/components/Code/tests/index.js
@@ -24,7 +24,7 @@ describe('components/Code', () => {
   });
 
   it('should render code that is passed in', () => {
-    let code = `var foo;`;
+    let code = 'var foo;';
 
     const componentInline = testHelpers.renderIntoDocument(
       <Code type="inline">{ code }</Code>

--- a/src/components/Code/tests/index.js
+++ b/src/components/Code/tests/index.js
@@ -1,9 +1,43 @@
-/* eslint-disable no-unused-vars */
 import React from 'react';
-import ReactDOM from 'react-dom';
-import ReactTestUtils from 'react-addons-test-utils';
 import * as testHelpers from '../../../utils/test-helpers';
 import Code from '../index';
-/* eslint-enable no-unused-vars */
 
-describe('components/Code', () => {});
+describe('components/Code', () => {
+  it('should render inline code in code tag', () => {
+    const component = testHelpers.renderIntoDocument(
+      <Code type="inline">{ 'var foo;' }</Code>
+    );
+
+    const componentNode = testHelpers.getNodeFromComponent(component);
+
+    expect(componentNode.tagName).toBe('CODE');
+  });
+
+  it('should render block code as preformatted text', () => {
+    const component = testHelpers.renderIntoDocument(
+      <Code type="block">{ 'var foo;' }</Code>
+    );
+
+    const componentNode = testHelpers.getNodeFromComponent(component);
+
+    expect(componentNode.tagName).toBe('PRE');
+  });
+
+  it('should render code that is passed in', () => {
+    let code = `var foo;`;
+
+    const componentInline = testHelpers.renderIntoDocument(
+      <Code type="inline">{ code }</Code>
+    );
+
+    const componentBlock = testHelpers.renderIntoDocument(
+      <Code type="block">{ code }</Code>
+    );
+
+    const componentInlineNode = testHelpers.getNodeFromComponent(componentInline);
+    const componentBlockNode = testHelpers.getNodeFromComponent(componentBlock);
+
+    expect(componentInlineNode.textContent).toBe(code);
+    expect(componentBlockNode.textContent).toBe(code);
+  });
+});


### PR DESCRIPTION
This adds a few tests for code samples and prevents them from being wrapped in `div`s.

cc: @tscanlin @daverau-optimizely @kwalker3690 