### PR TITLE
Add token and badge styles from V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 
 ## [Unreleased][Unreleased]
 - [Feature] Admin color helpers as separate partial, also added better HTML examples.
+- [Feature] Add token styles from V2.
+- [Feature] Add badge styles from V2.
 
 ## [11.5.0][11.5.0] - 2016-06-16
 ### Added

--- a/src/oui/_oui-partials.scss
+++ b/src/oui/_oui-partials.scss
@@ -48,6 +48,7 @@
 @import 'partials/components/accordion';
 @import 'partials/components/arrows-inline';
 @import 'partials/components/attention';
+@import 'partials/components/badge';
 @import 'partials/components/block-list';
 @import 'partials/components/dialog';
 @import 'partials/components/disclose';
@@ -67,3 +68,4 @@
 @import 'partials/components/stats';
 @import 'partials/components/steps';
 @import 'partials/components/tabs';
+@import 'partials/components/token';

--- a/src/oui/_oui-variables.scss
+++ b/src/oui/_oui-variables.scss
@@ -275,6 +275,13 @@ $token: (
     primary                  : #009DE0,
     secondary                : #869FAB
   ),
+  token__number: (
+    min-width                : 10px
+  ),
+  token__close: (
+    width                    : 12px,
+    height                   : 12px
+  ),
   border-radius              : 2px,
   text-shadow                : 0 0 1px rgba(0, 0, 0, 0.2),
   padding                    : 4px
@@ -284,7 +291,12 @@ $token: (
 /// Badge
 
 $badge: (
-  size                       : 14px
+  background-color           : #B4B7B9,
+  size                       : 14px,
+  min-width                  : 16px,
+  font-size                  : 10px,
+  font-weight                : 700,
+  letter-spacing             : 0.5px
 );
 
 

--- a/src/oui/_oui-variables.scss
+++ b/src/oui/_oui-variables.scss
@@ -267,6 +267,27 @@ $button: (
   )
 );
 
+
+/// Tokens
+
+$token: (
+  background-color: (
+    primary                  : #009DE0,
+    secondary                : #869FAB
+  ),
+  border-radius              : 2px,
+  text-shadow                : 0 0 1px rgba(0, 0, 0, 0.2),
+  padding                    : 4px
+);
+
+
+/// Badge
+
+$badge: (
+  size                       : 14px
+);
+
+
 /// Icons
 
 $icon: (

--- a/src/oui/partials/components/_badge.scss
+++ b/src/oui/partials/components/_badge.scss
@@ -20,16 +20,16 @@
   > li {
     height: map-fetch($badge, size);
     line-height: map-fetch($badge, size);
-    background: #B4B7B9;
+    background: map-fetch($badge, background-color);
     color: map-fetch($color, ui, white);
-    min-width: 16px;
+    min-width: map-fetch($badge, min-width);
     text-align: center;
-    margin-right: 5px;
+    margin-right: spacer(0.5);
     border-radius: map-fetch($badge, size);
-    font-size: 10px;
-    padding: 0 5px;
-    font-weight: 700;
-    letter-spacing: 0.5px;
+    font-size: map-fetch($badge, font-size);
+    padding: 0 spacer(0.5);
+    font-weight: map-fetch($badge, font-weight);
+    letter-spacing: map-fetch($badge, letter-spacing);
     text-transform: uppercase;
 
     &.badge__draft {

--- a/src/oui/partials/components/_badge.scss
+++ b/src/oui/partials/components/_badge.scss
@@ -1,0 +1,56 @@
+////
+/// Badge
+/// @group Components
+/// @description Useful for counts like the number of live or draft changes.
+/// @example[html] Draft
+///   <ul class="badge"><li class="badge__draft">2</li></ul>
+/// @example[html] Live
+///   <ul class="badge"><li class="badge__live">5</li></ul>
+/// @example[html] Primary
+///   <ul class="badge"><li class="badge__primary">1</li></ul>
+/// @example[html] Plain
+///   <ul class="badge"><li class="badge__plain">0</li></ul>
+////
+
+.#{$namespace}badge {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+
+  > li {
+    height: map-fetch($badge, size);
+    line-height: map-fetch($badge, size);
+    background: #B4B7B9;
+    color: map-fetch($color, ui, white);
+    min-width: 16px;
+    text-align: center;
+    margin-right: 5px;
+    border-radius: map-fetch($badge, size);
+    font-size: 10px;
+    padding: 0 5px;
+    font-weight: 700;
+    letter-spacing: .5px;
+    text-transform: uppercase;
+
+    &.badge__draft {
+      background: map-fetch($color, ui, draft);
+    }
+
+    &.badge__live {
+      background: map-fetch($color, ui, live);
+    }
+
+    &.badge__primary {
+      background: map-fetch($token, background-color, primary);
+    }
+
+    &.badge__plain {
+      background: transparent;
+      color: map-fetch($color, ui, medium);
+    }
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}

--- a/src/oui/partials/components/_badge.scss
+++ b/src/oui/partials/components/_badge.scss
@@ -29,7 +29,7 @@
     font-size: 10px;
     padding: 0 5px;
     font-weight: 700;
-    letter-spacing: .5px;
+    letter-spacing: 0.5px;
     text-transform: uppercase;
 
     &.badge__draft {

--- a/src/oui/partials/components/_token.scss
+++ b/src/oui/partials/components/_token.scss
@@ -32,7 +32,6 @@
 
 .#{$namespace}token-wrap {
   display: inline-flex;
-
   border: 1px solid map-fetch($color, ui, base);
   background: map-fetch($color, background, light);
   padding: map-fetch($token, padding);
@@ -42,7 +41,6 @@
 .#{$namespace}token {
   display: inline-flex;
   align-items: center;
-
   color: map-fetch($color, text, white);
   line-height: 1;
   padding: spacer(0.5) spacer(1);
@@ -76,7 +74,6 @@
 
 .#{$namespace}token__move {
   transform: rotate(90deg);
-
   color: darken(map-fetch($color, ui, base), 10);
 }
 

--- a/src/oui/partials/components/_token.scss
+++ b/src/oui/partials/components/_token.scss
@@ -46,7 +46,7 @@
   color: map-fetch($color, text, white);
   line-height: 1;
   padding: spacer(0.5) spacer(1);
-  border-radius: 2px;
+  border-radius: map-fetch($token, border-radius);
   text-shadow: map-fetch($token, text-shadow);
 }
 
@@ -71,14 +71,13 @@
 .#{$namespace}token__number {
   color: map-fetch($color, text, light);
   font-size: map-fetch($font, size, milli);
-  min-width: 10px;
+  min-width: map-fetch($token, token__number, min-width);
 }
 
 .#{$namespace}token__move {
   transform: rotate(90deg);
 
   color: darken(map-fetch($color, ui, base), 10);
-  margin-left: -2px;
 }
 
 .#{$namespace}token__description {
@@ -88,6 +87,6 @@
 
 .#{$namespace}token__close {
   color: map-fetch($color, ui, white);
-  height: 12px;
-  width: 12px;
+  height: map-fetch($token, token__close, height);
+  width: map-fetch($token, token__close, width);
 }

--- a/src/oui/partials/components/_token.scss
+++ b/src/oui/partials/components/_token.scss
@@ -1,0 +1,93 @@
+////
+/// Token
+/// @group Components
+/// @description Tokens are used to denote which items you’ve selected from a multi-select list.
+/// @example[html] secondary
+///   <div class="#{$namespace}token-wrap">
+///     <div class="#{$namespace}token #{$namespace}token--secondary">Experiment Page Title</div>
+///   </div>
+/// @example[html] primary
+///   <div class="#{$namespace}token-wrap">
+///     <div class="#{$namespace}token #{$namespace}token--primary">
+///       <span class="push--right">Experiment Page Title</span>
+///       <a class="flex">
+///         <svg class="#{$namespace}icon #{$namespace}token__close">
+///           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close-16"></use>
+///         </svg>
+///       </a>
+///     </div>
+///   </div>
+/// @example[html] primary
+///   <div class="#{$namespace}token-wrap">
+///     <div class="#{$namespace}token #{$namespace}token--primary">
+///       <span class="push--right">Experiment Page Title</span>
+///       <a class="flex">
+///         <svg class="#{$namespace}icon #{$namespace}token__close">
+///           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close-16"></use>
+///         </svg>
+///       </a>
+///     </div>
+///   </div>
+////
+
+.#{$namespace}token-wrap {
+  display: inline-flex;
+
+  border: 1px solid map-fetch($color, ui, base);
+  background: map-fetch($color, background, light);
+  padding: map-fetch($token, padding);
+  border-radius: map-fetch($token, border-radius);
+}
+
+.#{$namespace}token {
+  display: inline-flex;
+  align-items: center;
+
+  color: map-fetch($color, text, white);
+  line-height: 1;
+  padding: spacer(0.5) spacer(1);
+  border-radius: 2px;
+  text-shadow: map-fetch($token, text-shadow);
+}
+
+.#{$namespace}token--primary {
+  background: map-fetch($token, background-color, primary);
+}
+
+.#{$namespace}token--secondary {
+  background: map-fetch($token, background-color, secondary);
+}
+
+.#{$namespace}token-tool {
+  display: flex;
+  align-items: center;
+  cursor: move;
+  flex: none;
+  min-width: 0;
+  min-height: 0;
+  padding-left: map-fetch($token, padding) * 2;
+}
+
+.#{$namespace}token__number {
+  color: map-fetch($color, text, light);
+  font-size: map-fetch($font, size, milli);
+  min-width: 10px;
+}
+
+.#{$namespace}token__move {
+  transform: rotate(90deg);
+
+  color: darken(map-fetch($color, ui, base), 10);
+  margin-left: -2px;
+}
+
+.#{$namespace}token__description {
+  font-size: map-fetch($font, size, micro);
+  margin-top: spacer(0.5);
+}
+
+.#{$namespace}token__close {
+  color: map-fetch($color, ui, white);
+  height: 12px;
+  width: 12px;
+}


### PR DESCRIPTION
Added these from v2 without much modification. @kwalker3690 had a good point — that we should rename these classes down the road and do a search/replace update in the app for `.badge__primary` to `.badge--primary` — something to do in the near future.

Here's what the docs will look like:

![screenshot 2016-06-17 14 24 26](https://cloud.githubusercontent.com/assets/16581943/16165428/aea66a68-3498-11e6-8e2c-b17d8006bc01.png)

![screenshot 2016-06-17 14 24 52](https://cloud.githubusercontent.com/assets/16581943/16165431/b2c211b0-3498-11e6-9eac-49c8a9779fb1.png)
