### PR TITLE
Drau/revert tabnav examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 
 ## [Unreleased][Unreleased]
 ### Changed
+- [Patch] Revert TabNav examples, the minimal examples throw errors because those props are required.
 - [Patch] Updated icon default export syntax in bash script, new import syntax as well. (#506)
 - [Patch] Fix warnings for keys in ButtonRow example.
 

--- a/src/components/TabNav/example/index.js
+++ b/src/components/TabNav/example/index.js
@@ -35,13 +35,25 @@ export default [
     isPadded: true,
     examples: [
       <TabNav activeTab={ 'second' } style={ ['small'] }>
-        <TabNav.Tab>
+        <TabNav.Tab
+          tabId='first'
+          onClick={ function() {
+            alert('clicked first');  //eslint-disable-line
+          } }>
           Tab #1
         </TabNav.Tab>
-        <TabNav.Tab>
+        <TabNav.Tab
+          tabId='second'
+          onClick={ function() {
+            alert('clicked second');  //eslint-disable-line
+          } }>
           Tab #2
         </TabNav.Tab>
-        <TabNav.Tab>
+        <TabNav.Tab
+          tabId='third'
+          onClick={ function() {
+            alert('clicked third');  //eslint-disable-line
+          } }>
           Tab #3
         </TabNav.Tab>
       </TabNav>,
@@ -51,13 +63,25 @@ export default [
     isPadded: true,
     examples: [
       <TabNav activeTab={ 'first' } style={ ['small', 'center'] }>
-        <TabNav.Tab>
+        <TabNav.Tab
+          tabId='first'
+          onClick={ function() {
+            alert('clicked first');  //eslint-disable-line
+          } }>
           Tab #1
         </TabNav.Tab>
-        <TabNav.Tab>
+        <TabNav.Tab
+          tabId='second'
+          onClick={ function() {
+            alert('clicked second');  //eslint-disable-line
+          } }>
           Tab #2
         </TabNav.Tab>
-        <TabNav.Tab>
+        <TabNav.Tab
+          tabId='third'
+          onClick={ function() {
+            alert('clicked third');  //eslint-disable-line
+          } }>
           Tab #3
         </TabNav.Tab>
       </TabNav>,
@@ -67,13 +91,25 @@ export default [
     isPadded: true,
     examples: [
       <TabNav activeTab={ 'first' } style={ ['small', 'sub'] }>
-        <TabNav.Tab>
+        <TabNav.Tab
+          tabId='first'
+          onClick={ function() {
+            alert('clicked first');  //eslint-disable-line
+          } }>
           Tab #1
         </TabNav.Tab>
-        <TabNav.Tab>
+        <TabNav.Tab
+          tabId='second'
+          onClick={ function() {
+            alert('clicked second');  //eslint-disable-line
+          } }>
           Tab #2
         </TabNav.Tab>
-        <TabNav.Tab>
+        <TabNav.Tab
+          tabId='third'
+          onClick={ function() {
+            alert('clicked third');  //eslint-disable-line
+          } }>
           Tab #3
         </TabNav.Tab>
       </TabNav>,


### PR DESCRIPTION
Revert TabNav examples to original version, even though it's more code and scrolling in the docs, those props are required and reasoning about the component more clear.

cc @danoc 