### PR TITLE
Changelog fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased][Unreleased]
+### Added
+- [Feature] Add size class based on icon size prop. (#517)
+
 ### Changed
 - [Patch] Updated icon default export syntax in bash script, new import syntax as well. (#506)
 - [Patch] Fix warnings for keys in ButtonRow example.
@@ -38,6 +41,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 
 ## [14.0.5][14.0.5] - 2016-08-17
 ### Added
+- [Feature] Add isFilter prop to <Input> for search icon (#488)
 - [Patch] Update require.css statement to ignore local webpack config transforms. Minor version bump from publish issues (user error). (#498)
 - [Patch] Update require.css statement to ignore local webpack config transforms. Version patch bump due to publish user error. (#498)
 


### PR DESCRIPTION
This fixes the changelog to the correct state, post-merge of `drau/icon-examples` (https://github.com/optimizely/oui/commit/fc1ea0b275e5f2eb5d8ab3519110a64d213f8b7f#diff-4ac32a78649ca5bdd8e0ba38b7006a1e)

cc @danoc 