### PR TITLE
Use clipboard icon for copy copying in `Code` component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased][Unreleased]
-### Changed
-- [Patch] Fixup for React icon size prop warnings with proper array syntax in script. (#560)
-
 ### Added
 - [Feature] Add disclose--right modifier option for right-aligned arrow. (#553)
 
 ### Changed
 - [Patch] Convert `sync-oui-icons` bash script to Node.js. (#550)
+- [Patch] Use clipboard icon for copy copying in `Code` component. (#468)
 - [Patch] Add a default case to each icon component so that a non-standard size can be passed.
 - [Patch] Remove `svgo` since it was only minifying the SVGs locally and not in the published version of OUI.
+
+### Fixed
+- [Patch] Fixup for React icon size prop warnings with proper array syntax in script. (#560)
 
 ## [17.0.0][17.0.0] - 2016-09-07
 ### Changed

--- a/src/components/Code/CopyButton/index.js
+++ b/src/components/Code/CopyButton/index.js
@@ -21,13 +21,13 @@ class CopyButton extends React.Component {
     return (
       /* eslint-disable react/jsx-no-bind */
       <div
-        style={ { position: 'absolute', right: 0 } }
+        style={ { position: 'absolute', right: 0, top: '5px' } }
         ref={ (c) => { this._buttonContainer = c; } }>
         <Button
           style="plain"
           ariaLabel="Copy code snippet"
           testSection={ buttonTestSection }>
-          <ClipboardIcon size={ 16 } />
+          <ClipboardIcon />
         </Button>
       </div>
       /* eslint-enable */

--- a/src/components/Code/CopyButton/index.js
+++ b/src/components/Code/CopyButton/index.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { default as Clipboard } from 'clipboard';
+
+import Button from '../../Button';
+import ClipboardIcon from '../../Icon/ClipboardIcon';
+
+class CopyButton extends React.Component {
+  componentDidMount() {
+    this._clipboardListener = new Clipboard(this._buttonContainer, {
+      text: () => this.props.code,
+    });
+  }
+
+  componentWillUnmount() {
+    this._clipboardListener.destroy();
+  }
+
+  render() {
+    let buttonTestSection = this.props.testSection ? this.props.testSection + '-copy-button' : null;
+
+    return (
+      /* eslint-disable react/jsx-no-bind */
+      <div
+        style={ { position: 'absolute', right: 0 } }
+        ref={ (c) => { this._buttonContainer = c; } }>
+        <Button
+          style="plain"
+          ariaLabel="Copy code snippet"
+          testSection={ buttonTestSection }>
+          <ClipboardIcon size={ 16 } />
+        </Button>
+      </div>
+      /* eslint-enable */
+    );
+  }
+}
+
+CopyButton.propTypes = {
+  /** The code that will be copied */
+  code: React.PropTypes.string.isRequired,
+  /** Hook for automated JavaScript tests */
+  testSection: React.PropTypes.string,
+};
+
+export default CopyButton;

--- a/src/components/Code/CopyButton/tests/index.js
+++ b/src/components/Code/CopyButton/tests/index.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { default as Clipboard } from 'clipboard';
+import { mount } from 'enzyme';
+
+import CopyButton from '../index';
+
+describe('components/Code/CopyButton', () => {
+  it('should render a button', () => {
+    const component = mount(<CopyButton code="foo" />);
+    expect(component.find('button').length).toEqual(1);
+  });
+
+  it('should call clipboard function when button is clicked on', () => {
+    let code = 'var foo;';
+
+    spyOn(Clipboard.prototype, 'resolveOptions').and.stub();
+
+    mount(<CopyButton code={ code } />);
+
+    expect(Clipboard.prototype.resolveOptions.calls.argsFor(0)[0].text()).toEqual(code);
+  });
+
+  it('should destroy clipboard after button is clicked on', () => {
+    spyOn(Clipboard.prototype, 'destroy').and.stub();
+
+    const component = mount(<CopyButton code="goose" />);
+
+    component.unmount();
+
+    expect(Clipboard.prototype.destroy.calls.count()).toEqual(1);
+  });
+
+  it('should have a properly set test section', () => {
+    const component = mount(
+      <CopyButton code="goose" testSection="goose" />
+    );
+    expect(component.find('[data-test-section="goose-copy-button"]').length).toBe(1);
+  });
+});

--- a/src/components/Code/index.js
+++ b/src/components/Code/index.js
@@ -1,51 +1,7 @@
 import React from 'react';
-
-import Button from '../Button';
-
 import * as Highlight from 'highlight.js';
-import { default as Clipboard } from 'clipboard';
 
-/**
- * Copies the provided code when clicking on a copy button. It uses
- * clipboard.js to copy the text and hackily adds a temporary DOM node to
- * add a listener and simulate a click in order to get around weird
- * clipboard.js restrictions.
- * @param {Object} event - Click event
- * @param {String} code - Code to be copied
- */
-const onCopyClick = (event, code) => {
-  // Create a temporary element to serve as a click handler for clipboard.js.
-  let button = event.target;
-  let temporaryListenerNode = button.parentNode.insertBefore(document.createElement('button'), button);
-
-  let clipboardListener = new Clipboard(temporaryListenerNode, {
-    text: function() {
-      return code;
-    },
-  });
-
-  // Simulate a click on the temporary listener.
-  temporaryListenerNode.click();
-
-  // Clean up all the mess.
-  clipboardListener.destroy();
-  temporaryListenerNode.remove();
-};
-
-const CopyButton = (code, testSection) => {
-  let buttonTestSection = testSection ? testSection + '-copy-button' : null;
-
-  return (
-    <div style={ { position: 'absolute', right: 0 } }>
-      <Button
-        style="plain"
-        onClick={ function(event) { onCopyClick(event, code); } }
-        testSection={ buttonTestSection }>
-        Copy
-      </Button>
-    </div>
-  );
-};
+import CopyButton from './CopyButton';
 
 const HighlightedCode = (code, isHighlighted, language, className, testSection) => {
   let dangerouslySetInnerHTML = null;
@@ -81,14 +37,23 @@ const HighlightedCode = (code, isHighlighted, language, className, testSection) 
  * @returns {ReactElement}
  */
 const Code = (props) => {
+  let copy = null;
+
   if (props.type === 'inline') {
-    return HighlightedCode(props.children, props.isHighlighted, props.language, 'oui-code', props.testSection);
+    return HighlightedCode(props.children,
+      props.isHighlighted,
+      props.language,
+      'oui-code',
+      props.testSection);
+  }
+
+  if (props.hasCopyButton) {
+    copy = <CopyButton code={ props.children } testSection={ props.testSection } />;
   }
 
   return (
     <div className="position--relative">
-      { props.hasCopyButton ? CopyButton(props.children, props.testSection) : null }
-
+      { copy }
       <pre
         className="oui-pre"
         data-test-section={ props.testSection }>

--- a/src/components/Code/tests/index.js
+++ b/src/components/Code/tests/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { default as Clipboard } from 'clipboard';
 import Code from '../index';
 import { shallow, mount, render } from 'enzyme';
 
@@ -108,48 +107,6 @@ describe('components/Code', () => {
       );
 
       expect(component.find('[data-test-section="code-copy-button"]').length).toBe(1);
-    });
-
-    it('should call clipboard function when button is clicked on', () => {
-      let code = 'var foo;';
-
-      const component = mount(
-        <Code
-          type="block"
-          hasCopyButton={ true }
-          testSection="code">
-          { code }
-        </Code>
-      );
-
-      spyOn(Clipboard.prototype, 'onClick').and.stub();
-      spyOn(Clipboard.prototype, 'resolveOptions').and.stub();
-
-      const copyButton = component.find('[data-test-section="code-copy-button"]');
-      copyButton.simulate('click');
-
-      expect(Clipboard.prototype.resolveOptions.calls.argsFor(0)[0].text()).toEqual(code);
-      expect(Clipboard.prototype.onClick.calls.count()).toEqual(1);
-    });
-
-    it('should destroy clipboard after button is clicked on', () => {
-      let code = 'var foo;';
-
-      const component = mount(
-        <Code
-          type="block"
-          hasCopyButton={ true }
-          testSection="code">
-          { code }
-        </Code>
-      );
-
-      spyOn(Clipboard.prototype, 'destroy').and.stub();
-
-      const copyButton = component.find('[data-test-section="code-copy-button"]');
-      copyButton.simulate('click');
-
-      expect(Clipboard.prototype.destroy.calls.count()).toEqual(1);
     });
 
     it('should not add a copy button to inline code', () => {


### PR DESCRIPTION
Adds a much needed clipboard icon to the Code component.

![screenshot 2016-09-09 18 18 51](https://cloud.githubusercontent.com/assets/916038/18406956/e2f30a34-76b9-11e6-842f-a85caa3ae5a3.png)

This turns the copy button into a new `CopyButton` component (sort of a subcomponent), adds new tests and moves a few to the new component, and removes the hacky code I wrote a few weeks ago.

***
@daverau-optimizely, can you review please?