### PR TITLE
icon fixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased][Unreleased]
+### Changed
+- [Patch] Correct regression and mistaken size classes for icons in SCSS.
 
 ## [17.3.0][17.3.0] - 2016-09-16
 ### Added

--- a/src/components/IconSample/example/index.js
+++ b/src/components/IconSample/example/index.js
@@ -10,12 +10,12 @@ import ClipboardIcon from '../../Icon/ClipboardIcon';
 export default [
   {
     examples: [
-      <HelpIcon size={ 24 } />,
-      <UploadIcon size={ 24 } />,
-      <DuplicateIcon size={ 24 } />,
-      <SearchIcon size={ 24 } />,
-      <RefreshIcon size={ 24 } />,
-      <ClipboardIcon size={ 24 } />,
+      <HelpIcon size={ 12 } />,
+      <UploadIcon size={ 12 } />,
+      <DuplicateIcon size={ 12 } />,
+      <SearchIcon size={ 12 } />,
+      <RefreshIcon size={ 12 } />,
+      <ClipboardIcon size={ 12 } />,
     ],
   },
   {
@@ -26,6 +26,16 @@ export default [
       <SearchIcon size={ 16 } />,
       <RefreshIcon size={ 16 } />,
       <ClipboardIcon size={ 16 } />,
+    ],
+  },
+  {
+    examples: [
+      <HelpIcon size={ 24 } />,
+      <UploadIcon size={ 24 } />,
+      <DuplicateIcon size={ 24 } />,
+      <SearchIcon size={ 24 } />,
+      <RefreshIcon size={ 24 } />,
+      <ClipboardIcon size={ 24 } />,
     ],
   },
 ];

--- a/src/components/IconSample/index.js
+++ b/src/components/IconSample/index.js
@@ -34,6 +34,7 @@ const IconSample = (props) => {
 IconSample.propTypes = {
   /** Size of the icon */
   size: React.PropTypes.oneOf([
+    12,
     16,
     24,
   ]).isRequired,

--- a/src/oui/partials/components/_icons.scss
+++ b/src/oui/partials/components/_icons.scss
@@ -24,13 +24,13 @@
   }
 
   &--medium,
-  &--16 {
+  &--24 {
     width: map-fetch($icon, size, medium, width);
     height: map-fetch($icon, size, medium, height);
   }
 
   &--large,
-  &--24 {
+  &--32 {
     width: map-fetch($icon, size, large, width);
     height: map-fetch($icon, size, large, height);
   }


### PR DESCRIPTION
@danoc this fixes the icon regression issue.
1. My initial commit of icon class sizes was incorrect — now that maps correctly as `medium` to `24px` and `large` to `32px`
2. Add missing `12` value to Icon size prop array
3. Add examples for all 3 size sets