### PR TITLE
Force `npm test` to fail when the documentation can't be built.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased][Unreleased]
+### Fixed
+- [Patch] Force `npm test` to fail when the documentation can't be built. (#601)
 
 ## [18.1.0][18.1.0] - 2016-09-29
 ### Added

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "postversion": "npm run postversion:publish && npm run postversion:update-devel",
     "postversion:publish": "git push --follow-tags",
     "postversion:update-devel": "git checkout devel && git pull && git merge master && git push origin devel && git checkout master",
-    "react-docs": "gulp sass && react-docgen src/components/ -i tests -i example -i Icon > docs/data.json && mkdir -p ./dist/docs/css && cp -Rv ./dist/css ./dist/docs && cp ./docs/index.html ./dist/docs/index.html && webpack && browser-sync reload",
+    "react-docs": "gulp sass && react-docgen src/components/ -i tests -i example -i Icon > docs/data.json && mkdir -p ./dist/docs/css && cp -Rv ./dist/css ./dist/docs && cp ./docs/index.html ./dist/docs/index.html && webpack --bail && browser-sync reload",
     "react-docs:serve": "npm run react-docs && parallelshell 'npm run react-docs:onchange' 'npm run react-docs:browser-sync'",
     "react-docs:onchange": "onchange '(docs|src)/**/*.(jsx|js)' -- npm run react-docs",
     "react-docs:browser-sync": "browser-sync start --server dist/docs/"


### PR DESCRIPTION
This fixes #601.