### PR TITLE
Remove CloudFront CDN upload on version release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,27 +13,12 @@ before_deploy:
 - npm start
 # Remove `devDependencies` from `package.json` before it goes to npm.
 - ./node_modules/.bin/json -I -f package.json -e 'this.devDependencies={}'
-# Copy `dist/` CSS files into a folder for S3 upload.
-- mkdir -vp s3/$(node -e "console.log(require('./package.json').version);")
-- cp -v dist/css/* s3/$(node -e "console.log(require('./package.json').version);")
 # Prepare for deploying React documentation with SSH
 # https://oncletom.io/2016/travis-ssh-deploy/
 - eval "$(ssh-agent -s)"
 - chmod 600 $TRAVIS_BUILD_DIR/deploy_rsa
 - ssh-add $TRAVIS_BUILD_DIR/deploy_rsa
 deploy:
-- provider: s3
-  access_key_id:
-    secure: hUfpx4qlgXNxuq7fXCCI9BpbJ1aSQJFy58CtuDW077i3WULaoKJ5aTuVOPDQY3V+hgskj5ECWXG7i7o0ZiVAyBLR92IKJQiT5NvSWkEyw0WJ/L0b2QkVB9lx1sX2wzg6k03inJnPoUIYAkhAdtj1W6sMmLXbgOouhT7bsuYUi9M=
-  secret_access_key:
-    secure: sHcezDuWh9s341ruDx4pDMmjDWuoQ7cf5jhUQu3YyNQ8zaPRfVLztnYcJFZCUAznJi7Sswb3hIVvEQq+PXgd2YibdI6lXVrFff/cqbpRT9VBllIG9gRQbXcTJ22u+SzdB9ikE4wKqqZx2aUX1GpDIQc0TigsFmXhxNxKG8gkSik=
-  bucket: optimizely-oui
-  local-dir: s3
-  region: us-west-2
-  acl: public-read
-  on:
-    repo: optimizely/oui
-    tags: true
 - provider: npm
   email:
     secure: Y+A/HOGTYtASn+cHBFxslq52Ij8sdS5I+uvKiZF6466fwJytlGzdyR9e+4NGkul0UgJl3CUY5xKZ7LhyNBPxQUaG9DmlX8pkDiuHlcFlMbCtw+aTLhRS+pfpGbOlKZUWZcM5jZF+TvPIEqN/q5/p5kZnIqp9dmVijOSu7/t0zxA=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 - [Patch] Move Sass for `Textarea` to component folder. (#368)
 - [Patch] Move Sass for `Input` to component folder. (#368)
 - [Patch] Change `.nvmrc` to use the latest release in Node's "Boron" release.
+- [Patch] Remove CloudFront CDN upload on version release. (#706)
 
 ### Removed
 - [Release] Remove Sass placeholders for `textarea` and `input`. The placeholders are `%#{$namespace}text-input`,

--- a/README.md
+++ b/README.md
@@ -31,27 +31,6 @@ This "living" style guide uses [ScribeSass](https://github.com/optimizely/scribe
 
 ## Including OUI in your project
 
-There are two ways to include OUI in your project.
-
-### Pre-compiled CSS file
-
-This is a quick and easy way to add OUI to a project. It is the least flexible option but works well for small projects and and prototypes.
-
-You can include this pre-compiled version of OUI in your application:
-
-```html
-<link rel="stylesheet" href="https://oui.cdn.optimizely.com/23.0.0/oui.css">
-```
-
-Replace `23.0.0` with the [latest release](https://github.com/optimizely/oui/releases) if needed.
-
-`oui.css` contains the core OUI CSS.
-
-
-### Grab OUI Sass and React components from npm
-
-This option is great for developers that want to tightly integrate OUI into their existing Sass or use our React components.
-
 OUI is published as an npm module called `optimizely-oui` that contains Sass files and React components.
 
 To install:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "tether": "^1.3.7"
   },
   "devDependencies": {
-    "autoprefixer": "^6.6.1",
     "babel-cli": "^6.7.7",
     "babel-jest": "^18.0.0",
     "babel-preset-es2015": "^6.6.0",
@@ -36,9 +35,7 @@
     "lodash.find": "^4.6.0",
     "marked": "^0.3.6",
     "mkdirp": "^0.5.1",
-    "node-sass": "^4.3.0",
     "npm-run-all": "^3.1.0",
-    "postcss-cli": "^2.6.0",
     "postcss-loader": "^0.13.0",
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.1.0",
@@ -57,12 +54,11 @@
   },
   "scripts": {
     "test": "npm run eslint && npm run jest && codecov && npm run scss-lint && npm run icons:update && npm run docs:build",
-    "start": "bundle install && bundle update && npm install && npm run sass && npm run icons:update && npm run babel && npm run docs:build",
+    "start": "bundle install && bundle update && npm install && npm run icons:update && npm run babel && npm run docs:build",
     "jest": "jest --config .jest.config.json",
     "jest:watch": "jest --config .jest.config.json --watch",
     "eslint": "eslint --ext .jsx --ext .js . --ignore-path .gitignore --max-warnings 0",
     "scss-lint": "bundle exec scss-lint src/",
-    "sass": "mkdir -p dist/css && node-sass src/oui/oui.scss | postcss --use autoprefixer > dist/css/oui.css",
     "babel": "babel src/ --out-dir dist/js --ignore \"tests/*.js, src/js\"",
     "icons:update": "npm update oui-icons && node ./scripts/sync-oui-icons/index.js",
     "preversion": "git checkout master && git pull --rebase=false && npm install",


### PR DESCRIPTION
We used to upload a compiled version of our CSS to `oui.cdn.optimizely.com` but I'd like to remove this since it is no longer needed and the code that supports it is confusing/hard to debug.

This fixes #706.