### PR TITLE
Add a noBorder prop to TR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 ### Fixed
 - [Patch] Align token close button to top instead of center. (#733)
 
+### Added
+- [Feature] Add noBorder prop to Table.TR
+
 ## 25.2.1 - 2017-05-19
 ### Added
 - [Feature] Add more class options to Table and Table.TR

--- a/src/components/Table/TR/index.js
+++ b/src/components/Table/TR/index.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 const TR = (props) => {
   let classes = classNames({
     'oui-table-row--active': props.isActive,
+    'no-border': props.noBorder,
   });
   return (
     <tr
@@ -19,6 +20,8 @@ TR.propTypes = {
   children: React.PropTypes.node,
   /** If true, add active class */
   isActive: React.PropTypes.bool,
+  /** If true, add class to remove border */
+  noBorder: React.PropTypes.bool,
   /** Hook for automated JavaScript tests */
   testSection: React.PropTypes.string,
 };

--- a/src/components/Table/TR/tests/index.js
+++ b/src/components/Table/TR/tests/index.js
@@ -17,4 +17,9 @@ describe('components/Table/TR', () => {
     const component = shallow(<TR testSection="goose"></TR>);
     expect(component.is('[data-test-section="goose"]')).toBe(true);
   });
+
+  it('should render without a border if noBorder is passed', () => {
+    const component = shallow(<TR noBorder="true" testSection="goose"></TR>);
+    expect(component.hasClass('no-border')).toBe(true);
+  });
 });


### PR DESCRIPTION
Add a prop called `noBorder` that allows `Table.TR` to remove a potential border. I needed to be able to pretend that a second `Table.TR` is a part of the previous `Table.TR`.