### PR TITLE
Fix warning related to test framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-element-to-jsx-string": "^5.0.0",
     "react-ga": "^2.1.2",
     "react-router": "^3.0.1",
+    "react-test-renderer": "^15.6.1",
     "sass-loader": "^4.0.2",
     "scribesass-parser": "optimizely/scribesass-parser#9639a63cb8883c5341cd285af468c5949a06f66f",
     "style-loader": "^0.13.1",


### PR DESCRIPTION
This warning was showing when we run `yarn jest:watch` 

```
Warning: ReactTestUtils has been moved to react-dom/test-utils. Update references to remove this warning.
```
Reading through this issue [enzyme/issues/875](https://github.com/airbnb/enzyme/issues/875) I find that we can fix the problem by installing this package `react-test-renderer`. Effectively the warning got away and we don't have the warning anymore. 

@jackschlotthauer-optimizely & @daverau-optimizely 

