### PR TITLE
Drau/button plain focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Feature] Add focus styles to buttons. (#771)
 - [Feature] Add Input prop to control textAlign left/right. (#764)
 
 ## 26.2.3 - 2017-08-09

--- a/src/components/Button/index.scss
+++ b/src/components/Button/index.scss
@@ -99,6 +99,10 @@
       color: map-fetch($button, type, outline, color);
     }
 
+    &:focus {
+      border-color: map-fetch($button, type, outline, hover, border);
+    }
+
     &:hover {
       background-color: map-fetch($button, type, outline, background);
       border-color: map-fetch($button, type, outline, hover, border);
@@ -166,7 +170,7 @@
     box-shadow: none;
 
     &:focus {
-      border-color: map-fetch($button, type, danger-outline, border);
+      border-color: map-fetch($button, type, danger-outline, hover, border);
     }
 
     &:hover {
@@ -207,6 +211,12 @@
       border-color: transparent;
       background-color: transparent;
       box-shadow: none;
+    }
+  }
+
+  &--plain {
+    &:focus {
+      border-color: map-fetch($button, type, outline, hover, border);
     }
   }
 


### PR DESCRIPTION
Adds focus styles to buttons:
![button-hovers](https://user-images.githubusercontent.com/16581943/29228171-92a7c4c0-7e8d-11e7-81b3-5ba5b1d40436.gif)
