### PR TITLE
Drau/docs hidetests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Ignore tests for snapshots in docs.
 
 ## 26.5.0 - 2017-09-21
 - [Feature] Add new Dropdown component. (#795)

--- a/scripts/docs-generate.js
+++ b/scripts/docs-generate.js
@@ -14,7 +14,7 @@ const categories = ['components', 'overrides'];
 
 // Grab all of the components
 const componentFolders = glob.sync(`src/@(${categories.join('|')})/**/`, {
-  ignore: ['src/components/', 'src/overrides/', '**/tests/', '**/example/', '**/Icon/*', '**/Icon/'],
+  ignore: ['src/components/', 'src/overrides/', '**/tests/*', '**/tests/', '**/example/', '**/Icon/*', '**/Icon/'],
 });
 
 const files = {};


### PR DESCRIPTION
Quick fix to hide other tests/snapshots from the docs:
<img width="1062" alt="screenshot 2017-09-21 14 59 02" src="https://user-images.githubusercontent.com/16581943/30720724-8f58948c-9edd-11e7-93b6-e05fe5012317.png">
