### PR TITLE
TextField story and example.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Fixup TextField React example and storybook knob for isRequired.
 - [Patch] Add icons to React Storybook.
 - [Patch] Update Dropdown React example code in docs.
 

--- a/src/components/TextField/TextField.story.js
+++ b/src/components/TextField/TextField.story.js
@@ -24,6 +24,7 @@ stories
         isFilter={ boolean('isFilter', false) }
         isDropdown={ boolean('isDropdown', true) }
         isOptional={ boolean('isOptional', false) }
+        isRequired={ boolean('isRequired', false) }
         label={ text('Label', '') }
         max={ number('max', 50) }
         min={ number('min', 10) }
@@ -32,7 +33,6 @@ stories
         onBlur={ action('on blur') }
         onKeyDown={ action('on key press') }
         placeholder={ text('placeholder', 'just a placeholder') }
-        required={ boolean('required', false) }
         type={ select('type', ['text', 'password', 'number', 'date'], 'text') }
       />);
   }).add('TextField', () => {

--- a/src/components/TextField/example/index.js
+++ b/src/components/TextField/example/index.js
@@ -1,0 +1,29 @@
+/* eslint-disable react/jsx-key */
+import React from 'react';
+import TextField from '../index';
+
+export default [
+  {
+    examples: [
+      <TextField
+        label="Field label"
+        note="A short description or note about this field."
+        placeholder="Just a placeholder"
+        type="text"
+        isOptional={ true }
+      />,
+    ],
+  },
+  {
+    examples: [
+      <TextField
+        label="Field label with error"
+        displayError={ true }
+        note="A short description or note about this field."
+        placeholder="Just a placeholder"
+        type="text"
+        isRequired={ true }
+      />,
+    ],
+  },
+];


### PR DESCRIPTION
This PR adds a missing React code example for the TextField documentation as well as fixes a small prop knob for isRequired.