### PR TITLE
[BLOCKING DEPLOYS OF OPTLY] Remove padding on lego-disclose children

### DIFF
--- a/src/components/Disclose/index.scss
+++ b/src/components/Disclose/index.scss
@@ -64,6 +64,9 @@
     .#{$namespace}disclose__content,
     .oui-disclose__content {
       display: block;
+    }
+
+    .oui-disclose__content {
       *:last-child {
         padding-bottom: 20px;
       }


### PR DESCRIPTION
Currently, parts of the UI that use `lego-disclose` look messed up because of some extra padding:
![image](https://user-images.githubusercontent.com/729524/33412328-78eeb24c-d53f-11e7-9a13-cc74dcc9230f.png)

It seems like unchecking the `padding-bottom: 20px` seems to fix it. 

## Steps to repro:
1. `git checkout devel && git pull` 
2. `npm install && ulimit -S -n 10000 && grunt dev`
3. `grunt connect:local` 
4. Go to any page at app.optimizely.com with `?use_local_bundle=true`
5. Navigate to the following pages:
5.1. Change list sidebar
5.2. Audience creator thingy 
5.3. Anywhere the metrics picker is visible. 

**Actual**
There's a crazy amount of spacing under elements. Example:
![image](https://user-images.githubusercontent.com/729524/33412495-88ba775a-d540-11e7-8c42-6978d0c79710.png)


**Expected**
It shouldn't look so crazy! 
![image](https://user-images.githubusercontent.com/729524/33412498-938d740c-d540-11e7-924e-7280df4bd806.png)


## Steps to test my fix!! 

**NOTE: I tried to go through these steps and couldn't get it to work and it's late so I went home** 

(assuming you already have `grunt connect:local` running and are `use_local_bundle=true`-ing...)
1. In the `oui` repo, checkout and pull my branch
2. Run `npm start`. This will compile the assets into dist. 
2.1. I ran into issues when I tried to do this and had to do `rbenv local 2.3.1`
3. Run `npm link`. 
4. In the `optimizely` repo, go to `src/www/frontend` and type `npm link optimizely-oui`. This will get optimizely-oui to refer to the your local oui rather than the oui on npm. 
5. Run `npm install optimizely-oui && npm install && ulimit -S -n 10000 && grunt dev` from `src/www/frontend`
5.1. If you run into errors, then :(. You may need to do `rm -rf node_modules && npm cache clean` before you try this step.
6. Visit the pages from earlier. You may need to hard-reload or open a new tab with `use_local_bundle=true` 
7. **DON'T FORGET** When you are done testing, you can type `npm unlink optimizely-oui` to remove the symlink 


## More Screenshots of the actual behavior that we are trying to fix:

### Audience selector:
![image](https://user-images.githubusercontent.com/729524/33412353-996f6b06-d53f-11e7-9fde-5a40ad05b740.png)

### Change list sidebar:
![image](https://user-images.githubusercontent.com/729524/33412311-61301b00-d53f-11e7-8614-b05c787c9df2.png)

### Anything that uses a filter list with a disclose in it, incl. Metrics Picker
![image](https://user-images.githubusercontent.com/729524/33412363-aba5fbc8-d53f-11e7-942b-2fa79bfbcba4.png)



