### PR TITLE
Drau/scrollbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Feature] - Add .scrollbars--visible helper to show overflow container scroll bars (#863)
 - [Feature] - Allow Attention React Oui Component To Accept Other React Oui Components As Children (#737)
 
 ## 28.1.8 - 2017-12-01

--- a/src/oui/_oui-partials.scss
+++ b/src/oui/_oui-partials.scss
@@ -26,6 +26,7 @@
 @import 'partials/elements/links';
 @import 'partials/elements/lists';
 @import '../components/Radio/index';
+@import 'partials/elements/scrollbars';
 @import '../components/Select/index';
 @import '../components/Table/index';
 @import 'partials/elements/text';

--- a/src/oui/partials/elements/_scrollbars.scss
+++ b/src/oui/partials/elements/_scrollbars.scss
@@ -1,0 +1,26 @@
+////
+/// Scrollbars
+/// @description Helper to always show visible scroll bars on container elements with overflow.
+///
+/// @example[html] Adds always visible sroll bars.
+///   <div class="scrollbars--visible">
+///     ...
+///   </div>
+////
+.scrollbars--visible {
+  overflow-y: scroll;
+}
+.scrollbars--visible::-webkit-scrollbar,
+.scrollbars--visible::scrollbar {
+  -webkit-appearance: none;
+          appearance: none;
+  width: 7px;
+  background-color: rgba(0, 0, 0, .04);
+}
+.scrollbars--visible::-webkit-scrollbar-thumb,
+.scrollbars--visible::scrollbar-thumb {
+  border-radius: 8px;
+  background-color: rgba(0, 0, 0, .3);
+  -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+          box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+}


### PR DESCRIPTION
Adding scrollbar helper class so they are always visible on overflow containers. I'm assuming most people will use this for vertical scrolling so that's the default style I added here.

cc @circAssimilate 