### PR TITLE
Remove CSS syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] - Fix CSS syntax error for scrollbars--visible.
 
 ## 28.2.1 - 2017-12-15
 - [Patch] - Fix for lint errors on Card component mock function.

--- a/src/oui/partials/elements/_scrollbars.scss
+++ b/src/oui/partials/elements/_scrollbars.scss
@@ -10,15 +10,13 @@
 .scrollbars--visible {
   overflow-y: scroll;
 }
-.scrollbars--visible::-webkit-scrollbar,
-.scrollbars--visible::scrollbar {
+.scrollbars--visible::-webkit-scrollbar {
   -webkit-appearance: none;
           appearance: none;
   width: 7px;
   background-color: rgba(0, 0, 0, .04);
 }
-.scrollbars--visible::-webkit-scrollbar-thumb,
-.scrollbars--visible::scrollbar-thumb {
+.scrollbars--visible::-webkit-scrollbar-thumb {
   border-radius: 8px;
   background-color: rgba(0, 0, 0, .3);
   -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);


### PR DESCRIPTION
Remove non-standard CSS that was causing syntax errors. Silly mistake on my part.