### PR TITLE
use classes with recompose for predictable component names

### DIFF
--- a/src/components/Disclose/index.js
+++ b/src/components/Disclose/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { toClass } from 'recompose';
 import { withToggle } from '../../utils/recompose-utils';
 
-const Disclose = withToggle(({
+const Disclose = ({
   isOpen,
   children,
   headerStyle,
@@ -39,14 +40,16 @@ const Disclose = withToggle(({
       </div>
     </div>
   );
-});
+};
 
 Disclose.propTypes = {
   children: PropTypes.node.isRequired,
   childrenStyle: PropTypes.string,
   headerStyle: PropTypes.string,
+  isOpen: PropTypes.bool,
   noBorder: PropTypes.bool,
   title: PropTypes.string.isRequired,
+  toggle: PropTypes.func,
 };
 
-export default Disclose;
+export default withToggle(toClass(Disclose));

--- a/src/components/Disclose/tests/__snapshots__/index.js.snap
+++ b/src/components/Disclose/tests/__snapshots__/index.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Disclose Component  renders correctly 1`] = `
-<withHandlers(Component)
+<withHandlers(Disclose)
   isOpen={false}
   title="Some title"
   toggle={[Function]}
@@ -11,5 +11,5 @@ exports[`Disclose Component  renders correctly 1`] = `
     disclose this
   </div>
    
-</withHandlers(Component)>
+</withHandlers(Disclose)>
 `;

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -2,9 +2,10 @@ import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { Manager, Popper, Target } from 'react-popper';
+import { toClass } from 'recompose';
 import { withToggle } from '../../utils/recompose-utils';
 
-const Dropdown = withToggle(({
+const Dropdown = ({
   arrowIcon,
   buttonContent,
   children,
@@ -13,7 +14,6 @@ const Dropdown = withToggle(({
   isOpen,
   fullWidth,
   placement = 'bottom-start',
-  show,
   style,
   testSection,
   width = 200,
@@ -80,7 +80,7 @@ const Dropdown = withToggle(({
       </Popper>
     </Manager>
   );
-});
+};
 
 Dropdown.propTypes = {
   /** Arrow icon direction:
@@ -106,8 +106,10 @@ Dropdown.propTypes = {
   fullWidth: PropTypes.bool,
   /** Unused... */
   handleClick: PropTypes.func,
+  hide: PropTypes.func,
   /** Disable button. */
   isDisabled: PropTypes.bool,
+  isOpen: PropTypes.bool,
   /** Popper placement property */
   placement: PropTypes.oneOf([
     'top',
@@ -127,6 +129,7 @@ Dropdown.propTypes = {
   style: PropTypes.string,
   /** For automated testing only. */
   testSection: PropTypes.string,
+  toggle: PropTypes.func,
   /** Dropdown menu width, in pixels. */
   width: PropTypes.oneOfType([
     PropTypes.string,
@@ -140,4 +143,4 @@ Dropdown.defaultProps = {
   arrowIcon: 'none',
 };
 
-export default Dropdown;
+export default withToggle(toClass(Dropdown));

--- a/src/components/Dropdown/tests/__snapshots__/index.js.snap
+++ b/src/components/Dropdown/tests/__snapshots__/index.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/Dropdown should highlight button class when style equals highlight 1`] = `
-<withHandlers(Component)
-  arrowIcon="none"
+<withHandlers(Dropdown)
   buttonContent="Dropdown"
   icon={true}
   isOpen={false}
@@ -26,12 +25,11 @@ exports[`components/Dropdown should highlight button class when style equals hig
       Faster Results
     </li>
   </ul>
-</withHandlers(Component)>
+</withHandlers(Dropdown)>
 `;
 
 exports[`components/Dropdown should not render children when isDisabled is true 1`] = `
-<withHandlers(Component)
-  arrowIcon="none"
+<withHandlers(Dropdown)
   buttonContent="Dropdown"
   icon={true}
   idDisabled={true}
@@ -55,12 +53,11 @@ exports[`components/Dropdown should not render children when isDisabled is true 
       Faster Results
     </li>
   </ul>
-</withHandlers(Component)>
+</withHandlers(Dropdown)>
 `;
 
 exports[`components/Dropdown should not use .oui-arrow-inline--down when icon isEqual to triangle 1`] = `
-<withHandlers(Component)
-  arrowIcon="none"
+<withHandlers(Dropdown)
   buttonContent="Dropdown"
   icon={true}
   isOpen={false}
@@ -83,12 +80,11 @@ exports[`components/Dropdown should not use .oui-arrow-inline--down when icon is
       Faster Results
     </li>
   </ul>
-</withHandlers(Component)>
+</withHandlers(Dropdown)>
 `;
 
 exports[`components/Dropdown should render children when isOpen is true 1`] = `
-<withHandlers(Component)
-  arrowIcon="none"
+<withHandlers(Dropdown)
   buttonContent="Dropdown"
   icon={true}
   isOpen={false}
@@ -111,12 +107,11 @@ exports[`components/Dropdown should render children when isOpen is true 1`] = `
       Faster Results
     </li>
   </ul>
-</withHandlers(Component)>
+</withHandlers(Dropdown)>
 `;
 
 exports[`components/Dropdown should use oui-button--full class when fullWidth is true 1`] = `
-<withHandlers(Component)
-  arrowIcon="none"
+<withHandlers(Dropdown)
   buttonContent="Dropdown"
   fullWidth={true}
   icon={true}
@@ -140,5 +135,5 @@ exports[`components/Dropdown should use oui-button--full class when fullWidth is
       Faster Results
     </li>
   </ul>
-</withHandlers(Component)>
+</withHandlers(Dropdown)>
 `;


### PR DESCRIPTION
Use toClass for disclose/dropdown

This ensures predictable component names

i.e. `component.find('Disclose')` on an Enzyme wrapper will work.


Confirmed this ensures all unit tests pass for this Optimizely.git diff:
https://phabricator.optimizely.com/D19152