### PR TITLE
Adding Select Dropdown to OUI

### DIFF
--- a/src/components/Dropdown/Dropdown.story.js
+++ b/src/components/Dropdown/Dropdown.story.js
@@ -8,7 +8,6 @@ import { withInfo } from '@storybook/addon-info';
 
 import Dropdown from './index.js';
 import Button from '../Button';
-import BlockList from '../BlockList';
 import Icon from 'react-oui-icons';
 
 const data = [
@@ -34,24 +33,20 @@ stories.add('Default', withInfo()(() => {
         buttonContent='Default Dropdown'
         width={ number('width', 300) }
         arrowIcon={ true }>
-        <BlockList>
+        <Dropdown.Contents>
           {
             data.map((item, index) => {
               return (
-                <BlockList.Category header={ item.header } key={ index }>
-                  <BlockList.Item onClick={ action('click on complex item') }>
-                    <div className="flex flex-align--center">
-                      <div className="flex--1">
-                        <div>{ item.title }</div>
-                        <div className="muted micro">{ item.description }</div>
-                      </div>
-                    </div>
-                  </BlockList.Item>
-                </BlockList.Category>
+                <Dropdown.ListItem key={ index }>
+                  <Dropdown.BlockLink onClick={ action('click on complex item') }>
+                    <Dropdown.BlockLinkText text={ item.title } />
+                    <Dropdown.BlockLinkSecondaryText secondaryText={ item.description } />
+                  </Dropdown.BlockLink>
+                </Dropdown.ListItem>
               );
             })
           }
-        </BlockList>
+        </Dropdown.Contents>
       </Dropdown>
     </Container>
   );
@@ -65,24 +60,20 @@ stories.add('Error', withInfo()(() => {
         width={ number('width', 300) }
         displayError={ true }
         arrowIcon={ true }>
-        <BlockList>
+        <Dropdown.Contents>
           {
             data.map((item, index) => {
               return (
-                <BlockList.Category header={ item.header } key={ index }>
-                  <BlockList.Item onClick={ action('click on complex item') }>
-                    <div className="flex flex-align--center">
-                      <div className="flex--1">
-                        <div>{ item.title }</div>
-                        <div className="muted micro">{ item.description }</div>
-                      </div>
-                    </div>
-                  </BlockList.Item>
-                </BlockList.Category>
+                <Dropdown.ListItem key={ index }>
+                  <Dropdown.BlockLink onClick={ action('click on complex item') }>
+                    <Dropdown.BlockLinkText text={ item.title } />
+                    <Dropdown.BlockLinkSecondaryText secondaryText={ item.description } />
+                  </Dropdown.BlockLink>
+                </Dropdown.ListItem>
               );
             })
           }
-        </BlockList>
+        </Dropdown.Contents>
       </Dropdown>
     </Container>
   );
@@ -96,24 +87,20 @@ stories.add('Icon', withInfo()(() => {
         fullWidth={ boolean('fullWidth', false) }
         buttonContent={ <div>Hamburgers <span className="push-half--left"><Icon name='hamburger' /></span></div> }
         width={ number('width', 350) }>
-        <BlockList>
+        <Dropdown.Contents>
           {
             data.map((item, index) => {
               return (
-                <BlockList.Category header={ item.header } key={ index }>
-                  <BlockList.Item onClick={ action('click on complex item') }>
-                    <div className="flex flex-align--center">
-                      <div className="flex--1">
-                        <div>{ item.title }</div>
-                        <div className="muted micro">{ item.description }</div>
-                      </div>
-                    </div>
-                  </BlockList.Item>
-                </BlockList.Category>
+                <Dropdown.ListItem key={ index }>
+                  <Dropdown.BlockLink onClick={ action('click on complex item') }>
+                    <Dropdown.BlockLinkText text={ item.title } />
+                    <Dropdown.BlockLinkSecondaryText secondaryText={ item.description } />
+                  </Dropdown.BlockLink>
+                </Dropdown.ListItem>
               );
             })
           }
-        </BlockList>
+        </Dropdown.Contents>
       </Dropdown>
     </Container>
   );
@@ -128,24 +115,22 @@ stories.add('Z-index', withInfo()(() => {
             isDisabled={ boolean('isDisabled', false) }
             buttonContent='Dropdown'
             width={ number('width', 300) }>
-            <BlockList>
+            <Dropdown.Contents
+              minWidth={ 300 }
+              direction={ 'up' }>
               {
                 data.map((item, index) => {
                   return (
-                    <BlockList.Category header={ item.header } key={ index }>
-                      <BlockList.Item onClick={ action('click on complex item') }>
-                        <div className="flex flex-align--center">
-                          <div className="flex--1">
-                            <div>{ item.title }</div>
-                            <div className="muted micro">{ item.description }</div>
-                          </div>
-                        </div>
-                      </BlockList.Item>
-                    </BlockList.Category>
+                    <Dropdown.ListItem key={ index }>
+                      <Dropdown.BlockLink onClick={ action('click on complex item') }>
+                        <Dropdown.BlockLinkText text={ item.title } />
+                        <Dropdown.BlockLinkSecondaryText secondaryText={ item.description } />
+                      </Dropdown.BlockLink>
+                    </Dropdown.ListItem>
                   );
                 })
               }
-            </BlockList>
+            </Dropdown.Contents>
           </Dropdown>
           <h1>This text should be behind the open dropdown</h1>
         </ScrollContainer>

--- a/src/components/Dropdown/DropdownContents/index.js
+++ b/src/components/Dropdown/DropdownContents/index.js
@@ -25,7 +25,13 @@ export default function DropdownContents(props) {
       className={ classes }
       style={ styleProps }
       { ...(props.testSection ? { 'data-test-section': props.testSection } : {}) }>
-      { props.children }
+      {
+        React.Children.map(props.children, (child) => {
+          return child && React.cloneElement(child, {
+            handleToggle: props.handleToggle,
+          });
+        })
+      }
     </ul>
   );
 }
@@ -37,6 +43,11 @@ DropdownContents.propTypes = {
   children: PropTypes.node.isRequired,
   /** Direction of contents */
   direction: PropTypes.oneOf(['left', 'right', 'up']),
+  /**
+   * Function passed to children to determine
+   * if dropdown should be hidden
+   */
+  handleToggle: PropTypes.func,
   /** Whether to wrap contents or not */
   isNoWrap: PropTypes.bool,
   /** Minimum width of contents */
@@ -51,6 +62,7 @@ DropdownContents.propTypes = {
 DropdownContents.defaultProps = {
   canScroll: false,
   direction: 'left',
+  handleToggle: () => {},
   isNoWrap: false,
   testSection: '',
 };

--- a/src/components/Dropdown/DropdownContents/tests/index.js
+++ b/src/components/Dropdown/DropdownContents/tests/index.js
@@ -4,47 +4,47 @@ import { shallow } from 'enzyme';
 
 describe('components/Dropdown/DropdownContents', () => {
   it('should render as a `ul`', () => {
-    const component = shallow(<DropdownContents></DropdownContents>);
+    const component = shallow(<DropdownContents><div>foo</div></DropdownContents>);
     expect(component.type()).toBe('ul');
   });
 
   it('should render children', () => {
-    const component = shallow(<DropdownContents><li>foo</li></DropdownContents>);
+    const component = shallow(<DropdownContents><div>foo</div></DropdownContents>);
     expect(component.text()).toBe('foo');
   });
 
   it('should render with test section', () => {
-    const component = shallow(<DropdownContents testSection="goose"></DropdownContents>);
+    const component = shallow(<DropdownContents testSection="goose"><div>foo</div></DropdownContents>);
     expect(component.is('[data-test-section="goose"]')).toBe(true);
   });
 
   it('should render with nowrap', () => {
-    const component = shallow(<DropdownContents isNoWrap={ true }></DropdownContents>);
+    const component = shallow(<DropdownContents isNoWrap={ true }><div>foo</div></DropdownContents>);
     expect(component.find('ul').prop('className')).toBe('nowrap oui-dropdown oui-dropdown--right');
   });
 
   it('should render with default direction left', () => {
-    const component = shallow(<DropdownContents></DropdownContents>);
+    const component = shallow(<DropdownContents><div>foo</div></DropdownContents>);
     expect(component.find('ul').prop('className')).toBe('oui-dropdown oui-dropdown--right');
   });
 
   it('should render with direction right', () => {
-    const component = shallow(<DropdownContents direction={ 'right' }></DropdownContents>);
+    const component = shallow(<DropdownContents direction={ 'right' }><div>foo</div></DropdownContents>);
     expect(component.find('ul').prop('className')).toBe('oui-dropdown');
   });
 
   it('should render with direction up', () => {
-    const component = shallow(<DropdownContents direction={ 'up' }></DropdownContents>);
+    const component = shallow(<DropdownContents direction={ 'up' }><div>foo</div></DropdownContents>);
     expect(component.find('ul').prop('className')).toBe('oui-dropdown oui-dropdown--up');
   });
 
   it('should render with a minimum width', () => {
-    const component = shallow(<DropdownContents minWidth={ '300px' }></DropdownContents>);
+    const component = shallow(<DropdownContents minWidth={ '300px' }><div>foo</div></DropdownContents>);
     expect(component.find('ul').prop('style')).toEqual({ minWidth: '300px' });
   });
 
   it('should render with scroll styles if canScroll', () => {
-    const component = shallow(<DropdownContents canScroll={ true }></DropdownContents>);
+    const component = shallow(<DropdownContents canScroll={ true }><div>foo</div></DropdownContents>);
     expect(component.find('ul').prop('style')).toEqual({ overflowY: 'visible', maxHeight: 'auto' });
   });
 });

--- a/src/components/Dropdown/DropdownListItem/index.js
+++ b/src/components/Dropdown/DropdownListItem/index.js
@@ -3,16 +3,22 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 export default function DropdownListItem(props) {
+  function onClick() {
+    if (props.hideOnClick) {
+      props.handleToggle();
+    }
+  }
+
   const classes = classNames({
     'hard--sides': props.hardSides,
     'hard--top': props.hardTop,
     'oui-dropdown__item': true,
   });
 
-
   return (
     <li
-      className={ classes }>
+      className={ classes }
+      onClick={ onClick }>
       { props.children }
     </li>
   );
@@ -21,8 +27,16 @@ export default function DropdownListItem(props) {
 DropdownListItem.propTypes = {
   /** Nodes to display within */
   children: PropTypes.node,
+  /** Function to toggle visibility of Dropdown.Contents */
+  handleToggle: PropTypes.func,
   /** Remove padding from sides */
   hardSides: PropTypes.bool,
   /** Remove padding from top */
   hardTop: PropTypes.bool,
+  /** Whether to hide Dropdown.Contents when the item is clicked or not */
+  hideOnClick: PropTypes.bool,
+};
+
+DropdownListItem.defaultProps = {
+  hideOnClick: true,
 };

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -116,9 +116,12 @@ class Dropdown extends React.Component {
             boxShadow: '0 2px 3px rgba(0,0,0,.1)',
           }}
           onMouseOver={ this.onMouseOver }
-          onMouseLeave={ this.onMouseLeave }
-          onClick={ this.handleToggle }>
-          { isOpen && !isDisabled && children }
+          onMouseLeave={ this.onMouseLeave }>
+          { isOpen && !isDisabled && React.Children.map(children, (child) => {
+            return child && React.cloneElement(child, {
+              handleToggle: this.handleToggle,
+            });
+          }) }
         </Popper>
       </Manager>
     );

--- a/src/components/Dropdown/tests/__snapshots__/index.js.snap
+++ b/src/components/Dropdown/tests/__snapshots__/index.js.snap
@@ -36,7 +36,25 @@ exports[`components/Dropdown should include oui-form-bad-news class when display
   displayError={true}
   isOpen={false}
   toggle={[Function]}
-/>
+>
+  <ul>
+    <li
+      key="0"
+    >
+      Manual
+    </li>
+    <li
+      key="1"
+    >
+      Maximize Conventions
+    </li>
+    <li
+      key="2"
+    >
+      Faster Results
+    </li>
+  </ul>
+</withHandlers(withState(Dropdown))>
 `;
 
 exports[`components/Dropdown should not render children when isDisabled is true 1`] = `
@@ -107,7 +125,25 @@ exports[`components/Dropdown should render an activator node when passed as a pr
   displayError={true}
   isOpen={false}
   toggle={[Function]}
-/>
+>
+  <ul>
+    <li
+      key="0"
+    >
+      Manual
+    </li>
+    <li
+      key="1"
+    >
+      Maximize Conventions
+    </li>
+    <li
+      key="2"
+    >
+      Faster Results
+    </li>
+  </ul>
+</withHandlers(withState(Dropdown))>
 `;
 
 exports[`components/Dropdown should render children when isOpen is true 1`] = `

--- a/src/components/Dropdown/tests/index.js
+++ b/src/components/Dropdown/tests/index.js
@@ -136,6 +136,14 @@ describe('components/Dropdown', () => {
       <Dropdown
         buttonContent='Dropdown'
         displayError={ true }>
+        <ul>
+          { data.map((item, index) => {
+            return (
+              <li key={ index }>{ item.title }</li>
+            );
+          })
+          }
+        </ul>
       </Dropdown>
     );
     expect(shallowToJson(component)).toMatchSnapshot();
@@ -146,6 +154,14 @@ describe('components/Dropdown', () => {
       <Dropdown
         activator={ <button>Click me</button> }
         displayError={ true }>
+        <ul>
+          { data.map((item, index) => {
+            return (
+              <li key={ index }>{ item.title }</li>
+            );
+          })
+          }
+        </ul>
       </Dropdown>
     );
     expect(shallowToJson(component)).toMatchSnapshot();

--- a/src/components/SelectDropdown/SelectDropdown.story.js
+++ b/src/components/SelectDropdown/SelectDropdown.story.js
@@ -25,7 +25,6 @@ const items = [
   },
   {
     label: 'Dog',
-    description: 'Not a bear.',
     value: 'dog',
   },
   {

--- a/src/components/SelectDropdown/SelectDropdown.story.js
+++ b/src/components/SelectDropdown/SelectDropdown.story.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
+
+import SelectDropdown from './index.js';
+
+const stories = storiesOf('SelectDropdown', module);
+stories
+  .addDecorator(withKnobs)
+  .addDecorator(story => (
+    <div id="root-preview">
+      {story()}
+    </div>
+  ));
+
+stories.add('default', withInfo()(() => {
+  const items = [
+    {
+      label: 'Cat',
+      description: 'A small feline.',
+      value: 'cat',
+    },
+    {
+      label: 'Dog',
+      description: 'Not a bear.',
+      value: 'dog',
+    },
+    {
+      label: 'Bear',
+      description: 'Likes honey',
+      value: 'bear',
+    },
+    {
+      label: 'Squirrel',
+      description: 'Smarter than it looks',
+      value: 'squirrel',
+    },
+  ];
+
+  return (
+    <SelectDropdown
+      items={ items }
+      value={ 'dog' }
+      onChange={ action('SelectDropdown value changed') }
+    />
+  );
+}));

--- a/src/components/SelectDropdown/SelectDropdown.story.js
+++ b/src/components/SelectDropdown/SelectDropdown.story.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import styled from 'styled-components';
 
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { withKnobs } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
 
@@ -16,35 +17,59 @@ stories
     </div>
   ));
 
+const items = [
+  {
+    label: 'Cat',
+    description: 'A small feline.',
+    value: 'cat',
+  },
+  {
+    label: 'Dog',
+    description: 'Not a bear.',
+    value: 'dog',
+  },
+  {
+    label: 'Bear',
+    description: 'Likes honey',
+    value: 'bear',
+  },
+  {
+    label: 'Squirrel',
+    description: 'Smarter than it looks',
+    value: 'squirrel',
+  },
+];
+
 stories.add('default', withInfo()(() => {
-  const items = [
-    {
-      label: 'Cat',
-      description: 'A small feline.',
-      value: 'cat',
-    },
-    {
-      label: 'Dog',
-      description: 'Not a bear.',
-      value: 'dog',
-    },
-    {
-      label: 'Bear',
-      description: 'Likes honey',
-      value: 'bear',
-    },
-    {
-      label: 'Squirrel',
-      description: 'Smarter than it looks',
-      value: 'squirrel',
-    },
-  ];
 
   return (
-    <SelectDropdown
-      items={ items }
-      value={ 'dog' }
-      onChange={ action('SelectDropdown value changed') }
-    />
+    <Container>
+      <SelectDropdown
+        items={ items }
+        value={ 'dog' }
+        onChange={ action('SelectDropdown value changed') }
+        width={ '400px ' }
+      />
+    </Container>
   );
 }));
+
+stories.add('filter', withInfo()(() => {
+  return (
+    <Container>
+      <SelectDropdown
+        items={ items }
+        value={ 'dog' }
+        onChange={ action('SelectDropdown value changed') }
+        isFilterable={ true }
+        width={ '400px ' }
+      />
+    </Container>
+  );
+}));
+
+const Container = styled.div`
+  display: flex;
+  flex: 1;
+  height: 100vh;
+`;

--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -229,7 +229,7 @@ class SelectOption extends React.Component {
 
 SelectOption.defaultProps = {
   description: '',
-}
+};
 
 export default SelectDropdown;
 

--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -37,8 +37,8 @@ class SelectDropdown extends React.Component {
       description: PropTypes.string,
       label: PropTypes.string.isRequired,
       value: PropTypes.oneOfType([
-        PropTypes.string.isRequired,
-        PropTypes.number.isRequired,
+        PropTypes.string,
+        PropTypes.number,
         PropTypes.bool,
       ]).isRequired,
     })).isRequired,
@@ -85,6 +85,7 @@ class SelectDropdown extends React.Component {
 
   static defaultProps = {
     buttonStyle: 'outline',
+    inputPlaceholder: '',
     isFilterable: false,
     dropdownDirection: 'right',
     width: '100%',
@@ -103,7 +104,6 @@ class SelectDropdown extends React.Component {
   };
 
   filterTermValue = (value) => {
-
     return isFilterTermInItem(this.state.searchTerm, value);
   };
 
@@ -154,7 +154,7 @@ class SelectDropdown extends React.Component {
     return (
       <Dropdown
         width={ width }
-        zIndex={ zIndex }
+        { ...(zIndex ? { zIndex } : {}) }
         activator={ (
           <Button
             isDisabled={ this.props.isDisabled }
@@ -180,7 +180,7 @@ class SelectOption extends React.Component {
      */
     description: PropTypes.string,
     /** Toggle dropdown open/closed */
-    handleToggle: PropTypes.func,
+    handleToggle: PropTypes.func.isRequired,
     /**
      * Whether or not item has been selected or not.
      */
@@ -225,6 +225,10 @@ class SelectOption extends React.Component {
       </Dropdown.ListItem>
     );
   }
+}
+
+SelectOption.defaultProps = {
+  description: '',
 }
 
 export default SelectDropdown;

--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -10,13 +10,26 @@ import Dropdown from '../Dropdown';
 class SelectDropdown extends React.Component {
   static propTypes = {
     /**
-     * Boolean that determines whether or not the selector has the filter feature.
+     * Style value that is passed to the OUI button that controls the dropdown.
      */
-    isFilterable: PropTypes.bool,
+    buttonStyle: PropTypes.string,
+    /**
+     * Dropdown direction.
+     */
+    dropdownDirection: PropTypes.oneOf(['right', 'left']),
     /**
      * Placeholder text for the filter input.
      */
     inputPlaceholder: PropTypes.string,
+    /**
+     * The select is greyed out if it is disabled.
+     */
+    isDisabled: PropTypes.bool,
+    /**
+     * Boolean that determines whether or
+     * not the selector has the filter feature.
+     */
+    isFilterable: PropTypes.bool,
     /**
      * Dropdown items that can be selected from the select dropdown.
      */
@@ -30,29 +43,6 @@ class SelectDropdown extends React.Component {
       ]).isRequired,
     })).isRequired,
     /**
-     * Value of currently selected item.
-     */
-    value: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.bool,
-    ]).isRequired,
-    /**
-     * Function that is called when user selects another item from dropdown list.
-     */
-    onChange: PropTypes.func.isRequired,
-    /**
-     * Width of the activator container.
-     */
-    width: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-    /**
-     * The select is greyed out if it is disabled.
-     */
-    isDisabled: PropTypes.bool,
-    /**
      * The minimum width of the dropdown list; any valid CSS width value.
      */
     minDropdownWidth: PropTypes.oneOfType([
@@ -60,9 +50,10 @@ class SelectDropdown extends React.Component {
       PropTypes.number,
     ]),
     /**
-     * Dropdown direction.
+     * Function that is called when user selects
+     * an item from dropdown list.
      */
-    dropdownDirection: PropTypes.oneOf(['right', 'left']),
+    onChange: PropTypes.func.isRequired,
     /**
      * Identifier used to create data-test-section attributes for testing.
      */
@@ -72,9 +63,20 @@ class SelectDropdown extends React.Component {
      */
     trackId: PropTypes.string,
     /**
-     * Style value that is passed to the OUI button that controls the dropdown.
+     * Value of currently selected item.
      */
-    buttonStyle: PropTypes.string,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.bool,
+    ]).isRequired,
+    /**
+     * Width of the activator container.
+     */
+    width: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
     /**
      * zIndex of dropdown group
      */
@@ -114,8 +116,8 @@ class SelectDropdown extends React.Component {
     return (
       <Dropdown.Contents minWidth={ minDropdownWidth } direction={ dropdownDirection }>
         { isFilterable && (
-          <Dropdown.ListItem>
-            <form className="soft-half--ends lego-search">
+          <Dropdown.ListItem hideOnClick={ false }>
+            <form className="soft-half--ends oui-search">
               <Input
                 type="text"
                 isFilter={ true }
@@ -153,18 +155,18 @@ class SelectDropdown extends React.Component {
       <Dropdown
         width={ width }
         zIndex={ zIndex }
-        activator={(
+        activator={ (
           <Button
             isDisabled={ this.props.isDisabled }
             style={ buttonStyle }
             testSection={ this.props.testSection }
             width="full">
             <div className="flex flex-align--center" data-track-id={ this.props.trackId }>
-              <span style={ {overflow: 'hidden'} } className="flex flex--1">{ selectedItem.label }</span>
-              <span className="push--left lego-arrow-inline--down" />
+              <span style={{overflow: 'hidden'}} className="flex flex--1">{ selectedItem.label }</span>
+              <span className="push--left oui-arrow-inline--down" />
             </div>
           </Button>
-        )}>
+        ) }>
         { this.renderContents() }
       </Dropdown>
     );
@@ -177,6 +179,20 @@ class SelectOption extends React.Component {
      * Description of select item.
      */
     description: PropTypes.string,
+    /** Toggle dropdown open/closed */
+    handleToggle: PropTypes.func,
+    /**
+     * Whether or not item has been selected or not.
+     */
+    isSelected: PropTypes.bool.isRequired,
+    /**
+     * Label of select item.
+     */
+    label: PropTypes.string.isRequired,
+    /**
+     * Function that is called when user selects another item.
+     */
+    onChange: PropTypes.func.isRequired,
     /**
      * Value of select item.
      */
@@ -185,18 +201,6 @@ class SelectOption extends React.Component {
       PropTypes.number,
       PropTypes.bool,
     ]).isRequired,
-    /**
-     * Label of select item.
-     */
-    label: PropTypes.string.isRequired,
-    /**
-     * Whether or not item has been selected or not.
-     */
-    isSelected: PropTypes.bool.isRequired,
-    /**
-     * Function that is called when user selects another item.
-     */
-    onChange: PropTypes.func.isRequired,
   };
 
   onClick = () => {
@@ -204,9 +208,9 @@ class SelectOption extends React.Component {
   };
 
   render() {
-    const { isSelected, label, description, value } = this.props;
+    const { isSelected, label, description, value, handleToggle } = this.props;
     return (
-      <Dropdown.ListItem hideOnClick={ true }>
+      <Dropdown.ListItem hideOnClick={ true } handleToggle={ handleToggle }>
         <Dropdown.BlockLink
           isLink={ !isSelected }
           onClick={ this.onClick }

--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -1,0 +1,227 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { isFilterTermInItem } from '../../utils/filter';
+
+import Button from '../Button';
+import Input from '../Input';
+import Dropdown from '../Dropdown';
+
+
+class SelectDropdown extends React.Component {
+  static propTypes = {
+    /**
+     * Boolean that determines whether or not the selector has the filter feature.
+     */
+    isFilterable: PropTypes.bool,
+    /**
+     * Placeholder text for the filter input.
+     */
+    inputPlaceholder: PropTypes.string,
+    /**
+     * Dropdown items that can be selected from the select dropdown.
+     */
+    items: PropTypes.arrayOf(PropTypes.shape({
+      description: PropTypes.string,
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.string.isRequired,
+        PropTypes.number.isRequired,
+        PropTypes.bool,
+      ]).isRequired,
+    })).isRequired,
+    /**
+     * Value of currently selected item.
+     */
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.bool,
+    ]).isRequired,
+    /**
+     * Function that is called when user selects another item from dropdown list.
+     */
+    onChange: PropTypes.func.isRequired,
+    /**
+     * Width of the activator container.
+     */
+    width: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+    /**
+     * The select is greyed out if it is disabled.
+     */
+    isDisabled: PropTypes.bool,
+    /**
+     * The minimum width of the dropdown list; any valid CSS width value.
+     */
+    minDropdownWidth: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+    /**
+     * Dropdown direction.
+     */
+    dropdownDirection: PropTypes.oneOf(['right', 'left']),
+    /**
+     * Identifier used to create data-test-section attributes for testing.
+     */
+    testSection: PropTypes.string,
+    /**
+     * Identifier used to create data-track-id attributes for Heap testing.
+     */
+    trackId: PropTypes.string,
+    /**
+     * Style value that is passed to the OUI button that controls the dropdown.
+     */
+    buttonStyle: PropTypes.string,
+    /**
+     * zIndex of dropdown group
+     */
+    zIndex: PropTypes.number,
+  };
+
+  static defaultProps = {
+    buttonStyle: 'outline',
+    isFilterable: false,
+    dropdownDirection: 'right',
+    width: '100%',
+    trackId: '',
+    testSection: '',
+  };
+
+  state = {
+    searchTerm: '',
+  };
+
+  search = (event) => {
+    this.setState({
+      searchTerm: event.target.value,
+    });
+  };
+
+  filterTermValue = (value) => {
+
+    return isFilterTermInItem(this.state.searchTerm, value);
+  };
+
+  renderContents = () => {
+    const { items, value, minDropdownWidth, dropdownDirection, isFilterable, inputPlaceholder } = this.props;
+    const itemsToDisplay = items.filter(item => {
+      return this.filterTermValue(item.label);
+    });
+
+    return (
+      <Dropdown.Contents minWidth={ minDropdownWidth } direction={ dropdownDirection }>
+        { isFilterable && (
+          <Dropdown.ListItem>
+            <form className="soft-half--ends lego-search">
+              <Input
+                type="text"
+                isFilter={ true }
+                value={ this.state.searchTerm }
+                placeholder={ inputPlaceholder }
+                onChange={ this.search }
+              />
+            </form>
+          </Dropdown.ListItem>
+        )}
+        { itemsToDisplay.map((entry, index) => (
+          <SelectOption
+            key={ index }
+            onChange={ this.props.onChange }
+            value={ entry.value }
+            label={ entry.label }
+            description={ entry.description }
+            isSelected={ entry.value === value }
+          />
+        ))}
+      </Dropdown.Contents>
+    );
+  };
+
+  render() {
+    const { buttonStyle, value, width, zIndex } = this.props;
+    let selectedItem;
+    this.props.items.forEach(item => {
+      if (item.value === value) {
+        selectedItem = item;
+      }
+    });
+
+    return (
+      <Dropdown
+        width={ width }
+        zIndex={ zIndex }
+        activator={(
+          <Button
+            isDisabled={ this.props.isDisabled }
+            style={ buttonStyle }
+            testSection={ this.props.testSection }
+            width="full">
+            <div className="flex flex-align--center" data-track-id={ this.props.trackId }>
+              <span style={ {overflow: 'hidden'} } className="flex flex--1">{ selectedItem.label }</span>
+              <span className="push--left lego-arrow-inline--down" />
+            </div>
+          </Button>
+        )}>
+        { this.renderContents() }
+      </Dropdown>
+    );
+  }
+}
+
+class SelectOption extends React.Component {
+  static propTypes = {
+    /**
+     * Description of select item.
+     */
+    description: PropTypes.string,
+    /**
+     * Value of select item.
+     */
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.bool,
+    ]).isRequired,
+    /**
+     * Label of select item.
+     */
+    label: PropTypes.string.isRequired,
+    /**
+     * Whether or not item has been selected or not.
+     */
+    isSelected: PropTypes.bool.isRequired,
+    /**
+     * Function that is called when user selects another item.
+     */
+    onChange: PropTypes.func.isRequired,
+  };
+
+  onClick = () => {
+    this.props.onChange(this.props.value);
+  };
+
+  render() {
+    const { isSelected, label, description, value } = this.props;
+    return (
+      <Dropdown.ListItem hideOnClick={ true }>
+        <Dropdown.BlockLink
+          isLink={ !isSelected }
+          onClick={ this.onClick }
+          testSection={ 'dropdown-block-link-' + value }>
+          { label }
+          { description && (
+            <div className="micro muted">
+              { description }
+            </div>
+          )}
+        </Dropdown.BlockLink>
+      </Dropdown.ListItem>
+    );
+  }
+}
+
+export default SelectDropdown;
+

--- a/src/components/SelectDropdown/tests/index.js
+++ b/src/components/SelectDropdown/tests/index.js
@@ -1,64 +1,87 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import SelectDropdown from './index';
+import SelectDropdown from '../index';
 
-describe('react_components/select_dropdown', function() {
+describe('components/SelectDropdown', function() {
   let component;
   let onChange;
+  const items = [
+    {
+      label: 'label 1',
+      value: 'value 1',
+      description: 'description 1',
+    },
+    {
+      label: 'label 2',
+      value: 'value 2',
+      description: 'description 2',
+    },
+  ];
 
   beforeEach(function() {
-    onChange = sinon.spy();
-    const items = [
-      {
-        label: 'label 1',
-        value: 'value 1',
-        description: 'description 1',
-      },
-      {
-        label: 'label 2',
-        value: 'value 2',
-        description: 'description 2',
-      },
-    ];
-    component = mount(<SelectDropdown isFilterable={ true } items={ items } value={ 'value 2' } onChange={ onChange } />);
+    onChange = jest.fn();
   });
 
-  it('should filter items in dropdown', function() {
-    const input = component.find.bind(component, 'Input');
-    input().simulate('change', {target: {value: '1'}});
+  describe('without a filter', function() {
+    beforeEach(function() {
+      component = mount(<SelectDropdown isFilterable={ false } items={ items } value={ 'value 2' } onChange={ onChange } />);
+    })
 
-    const listItems = component.find('SelectOption');
-    expect(listItems).to.have.length(1);
+    it('should render all items in dropdown', function() {
+      const activator = component.find('Button');
+      activator.simulate('click');
+      const listItems = component.find('SelectOption');
+      expect(listItems).toHaveLength(2);
 
-    const item1 = listItems.at(0);
-    expect(item1.text()).to.contain('label 1');
-    expect(item1.text()).to.contain('description 1');
+      const item1 = listItems.at(0);
+      expect(item1.text()).toContain('label 1');
+      expect(item1.text()).toContain('description 1');
+      expect(item1.props().isSelected).toEqual(false);
 
-    input().simulate('change', {target: {value: 'INVALID_VALUE'}});
-    expect(component.find('SelectOption')).to.have.length(0);
-  });
+      const item2 = listItems.at(1);
+      expect(item2.text()).toContain('label 2');
+      expect(item2.text()).toContain('description 2');
+      expect(item2.props().isSelected).toEqual(true);
+    });
 
-  it('should render all items in dropdown', function() {
-    const listItems = component.find('SelectOption');
-    expect(listItems).to.have.length(2);
+    it('should call onChange when another item is selected', function() {
+      const activator = component.find('Button');
+      activator.simulate('click');
+      const listItems = component.find('DropdownBlockLink');
+      const item1 = listItems.at(0).find('[data-test-section="dropdown-block-link-value 1"]');
+      item1.simulate('click');
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith('value 1');
+    });
 
-    const item1 = listItems.at(0);
-    expect(item1.text()).to.contain('label 1');
-    expect(item1.text()).to.contain('description 1');
-    expect(item1.props().isSelected).to.equal(false);
+    it('should not add an input if isFilterable is false', function() {
+      const activator = component.find('Button');
+      activator.simulate('click');
+      const input = component.find('Input');
+      expect(input).toHaveLength(0);
+    })
+  })
 
-    const item2 = listItems.at(1);
-    expect(item2.text()).to.contain('label 2');
-    expect(item2.text()).to.contain('description 2');
-    expect(item2.props().isSelected).to.equal(true);
-  });
+  describe('with a filter', function() {
+    beforeEach(function() {
+      component = mount(<SelectDropdown isFilterable={ true } items={ items } value={ 'value 2' } onChange={ onChange } />);
+    })
+    it('should filter items in dropdown', function() {
+      const activator = component.find('Button');
+      activator.simulate('click');
+      const input = component.find('Input');
+      input.simulate('change', {target: {value: '1'}});
 
-  it('should call onChange when another item is selected', function() {
-    const listItems = component.find('DropdownBlockLink');
-    const item1 = listItems.at(0).find('[data-test-section="dropdown-block-link-value 1"]');
-    item1.simulate('click');
-    sinon.assert.calledOnce(onChange);
-    sinon.assert.calledWithExactly(onChange, 'value 1');
-  });
+      const listItems = component.find('SelectOption');
+      expect(listItems).toHaveLength(1);
+
+      const item1 = listItems.at(0);
+      expect(item1.text()).toContain('label 1');
+      expect(item1.text()).toContain('description 1');
+
+      input.simulate('change', {target: {value: 'INVALID_VALUE'}});
+      expect(component.find('SelectOption')).toHaveLength(0);
+    });
+  })
 });

--- a/src/components/SelectDropdown/tests/index.js
+++ b/src/components/SelectDropdown/tests/index.js
@@ -26,7 +26,7 @@ describe('components/SelectDropdown', function() {
   describe('without a filter', function() {
     beforeEach(function() {
       component = mount(<SelectDropdown isFilterable={ false } items={ items } value={ 'value 2' } onChange={ onChange } />);
-    })
+    });
 
     it('should render all items in dropdown', function() {
       const activator = component.find('Button');
@@ -60,13 +60,13 @@ describe('components/SelectDropdown', function() {
       activator.simulate('click');
       const input = component.find('Input');
       expect(input).toHaveLength(0);
-    })
-  })
+    });
+  });
 
   describe('with a filter', function() {
     beforeEach(function() {
       component = mount(<SelectDropdown isFilterable={ true } items={ items } value={ 'value 2' } onChange={ onChange } />);
-    })
+    });
     it('should filter items in dropdown', function() {
       const activator = component.find('Button');
       activator.simulate('click');
@@ -83,5 +83,5 @@ describe('components/SelectDropdown', function() {
       input.simulate('change', {target: {value: 'INVALID_VALUE'}});
       expect(component.find('SelectOption')).toHaveLength(0);
     });
-  })
+  });
 });

--- a/src/components/SelectDropdown/tests/index.js
+++ b/src/components/SelectDropdown/tests/index.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SelectDropdown from './index';
+
+describe('react_components/select_dropdown', function() {
+  let component;
+  let onChange;
+
+  beforeEach(function() {
+    onChange = sinon.spy();
+    const items = [
+      {
+        label: 'label 1',
+        value: 'value 1',
+        description: 'description 1',
+      },
+      {
+        label: 'label 2',
+        value: 'value 2',
+        description: 'description 2',
+      },
+    ];
+    component = mount(<SelectDropdown isFilterable={ true } items={ items } value={ 'value 2' } onChange={ onChange } />);
+  });
+
+  it('should filter items in dropdown', function() {
+    const input = component.find.bind(component, 'Input');
+    input().simulate('change', {target: {value: '1'}});
+
+    const listItems = component.find('SelectOption');
+    expect(listItems).to.have.length(1);
+
+    const item1 = listItems.at(0);
+    expect(item1.text()).to.contain('label 1');
+    expect(item1.text()).to.contain('description 1');
+
+    input().simulate('change', {target: {value: 'INVALID_VALUE'}});
+    expect(component.find('SelectOption')).to.have.length(0);
+  });
+
+  it('should render all items in dropdown', function() {
+    const listItems = component.find('SelectOption');
+    expect(listItems).to.have.length(2);
+
+    const item1 = listItems.at(0);
+    expect(item1.text()).to.contain('label 1');
+    expect(item1.text()).to.contain('description 1');
+    expect(item1.props().isSelected).to.equal(false);
+
+    const item2 = listItems.at(1);
+    expect(item2.text()).to.contain('label 2');
+    expect(item2.text()).to.contain('description 2');
+    expect(item2.props().isSelected).to.equal(true);
+  });
+
+  it('should call onChange when another item is selected', function() {
+    const listItems = component.find('DropdownBlockLink');
+    const item1 = listItems.at(0).find('[data-test-section="dropdown-block-link-value 1"]');
+    item1.simulate('click');
+    sinon.assert.calledOnce(onChange);
+    sinon.assert.calledWithExactly(onChange, 'value 1');
+  });
+});

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -11,4 +11,4 @@ export const isFilterTermInItem = function isFilterTermInItem(stringToFind, cont
     }
   }
   return true;
-}
+};

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -1,0 +1,14 @@
+export const isFilterTermInItem = function isFilterTermInItem(stringToFind, contentToSearch) {
+  if (!contentToSearch) {
+    return false;
+  }
+
+  const filters = stringToFind.match(/\S+/g) || [];
+
+  for (let i = 0; i < filters.length; i++) {
+    if (contentToSearch.toLocaleLowerCase().indexOf(filters[i].toLocaleLowerCase()) === -1) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
This diff moves react_components/select_dropdown to OUI as SelectDropdown. To enable the filtering functionality of SelectDropdown, Dropdown had to be refactored so that clicking on DropdownListItem toggles the Popper contents to be hidden. Previously, clicking on the Popper itself hid the contents - this meant that if a user tried to click into the filter input in a SelectDropdown, the dropdown contents would be hidden. 

This means that users of the Dropdown either must use Dropdown.ListItem, or must call this.props.handleToggle when the Dropdown should be closed. IMO, strongly encouraging use of Dropdown.ListItem in the contents of the Popper should be our approach, this will help us continue to have consistently styled Dropdowns.