### PR TITLE
Hide input number spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 
 ## Unreleased
 ### Changed
+- [Patch] Update reset CSS to hide number-input-spinners. (#964)
 - [Patch] Add index.js back from OUI version `7.0.0` for `design-dot` OUI upgrade to latest version. (#962)
 
 ### Added
-- [Feature] DropdownContents, DropdownListItem, DropdownBlockLink, DropdownBlockLinkText, DropdownBlockLinkSecondaryText components added to Dropdown 
+- [Feature] DropdownContents, DropdownListItem, DropdownBlockLink, DropdownBlockLinkText, DropdownBlockLinkSecondaryText components added to Dropdown
 - [Feature] Add onBlur prop to Button
 
 ### Fixed

--- a/src/oui/partials/elements/_reset.scss
+++ b/src/oui/partials/elements/_reset.scss
@@ -258,3 +258,11 @@ input[type="submit"] {
 :-ms-input-placeholder {
   color: map-fetch($color, text, muted);
 }
+
+// Keep number inputs consistent for alignment/proximity to `%` symbol
+// https://css-tricks.com/snippets/css/turn-off-number-input-spinners/
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}


### PR DESCRIPTION
This fixes an issue where number/percent input text isn't properly aligned due to the number spinners in Chrome/Safari. This removes this styling for these browsers:

<img width="949" alt="screen shot 2018-06-19 at 1 13 36 pm" src="https://user-images.githubusercontent.com/16581943/41622017-34c1f78c-73c3-11e8-9d78-b498a5d26e90.png">
