### PR TITLE
Make handleToggle not required as prop in SelectOption

### DIFF
--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -180,7 +180,7 @@ class SelectOption extends React.Component {
      */
     description: PropTypes.string,
     /** Toggle dropdown open/closed */
-    handleToggle: PropTypes.func.isRequired,
+    handleToggle: PropTypes.func,
     /**
      * Whether or not item has been selected or not.
      */
@@ -229,6 +229,7 @@ class SelectOption extends React.Component {
 
 SelectOption.defaultProps = {
   description: '',
+  handleToggle: () => {},
 };
 
 export default SelectDropdown;


### PR DESCRIPTION
handleToggle is passed as a prop through React.cloneElement, which means that when instantiated, SelectOption is not passed a handleToggle function as a prop. This causes an prop validation error, even though the component works as expected. This diff makes the handleToggle prop not required and adds a default value.