### PR TITLE
Add note to Input, and note and label to Textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+### Added
+- [Feature] Added note to Input 
+- [Feature] Added note and Label to Textarea
 
 ## 31.6.0 - 2018-06-21
 ### Added

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -79,7 +79,7 @@ class Input extends React.Component {
   }
 
   renderNote({note, testSection}) {
-    return (<div className='oui-form-note' data-test-section={ testSection && testSection + '-note' }>{note}</div>)
+    return (<div className='oui-form-note' data-test-section={ testSection && testSection + '-note' }>{note}</div>);
   }
 
   render() {
@@ -88,7 +88,7 @@ class Input extends React.Component {
       displayError,
       testSection,
       isOptional,
-      note
+      note,
     } = this.props;
 
     if (label) {
@@ -114,10 +114,10 @@ class Input extends React.Component {
           { this.renderInput(this.props) }
           { this.renderNote(this.props) }
         </div>
-      )
+      );
     }
 
-    return this.renderInput(this.props)
+    return this.renderInput(this.props);
 
   }
 }

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -109,12 +109,10 @@ class Input extends React.Component {
     }
 
     if (note) {
-      return (
-        <div>
-          { this.renderInput(this.props) }
-          { this.renderNote(this.props) }
-        </div>
-      );
+      return [
+        this.renderInput(this.props),
+        this.renderNote(this.props),
+      ];
     }
 
     return this.renderInput(this.props);
@@ -189,6 +187,10 @@ Input.propTypes = {
   ]).isRequired,
   /** Text within the input */
   value: PropTypes.string,
+};
+
+Input.defaultProps = {
+  note: null,
 };
 
 export default Input;

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -78,12 +78,17 @@ class Input extends React.Component {
     );
   }
 
+  renderNote({note, testSection}) {
+    return (<div className='oui-form-note' data-test-section={ testSection && testSection + '-note' }>{note}</div>)
+  }
+
   render() {
     const {
       label,
       displayError,
       testSection,
       isOptional,
+      note
     } = this.props;
 
     if (label) {
@@ -98,11 +103,22 @@ class Input extends React.Component {
             </div>
             { this.renderInput(this.props) }
           </Label>
+          { note && this.renderNote(this.props)}
         </div>
       );
     }
 
-    return this.renderInput(this.props);
+    if (note) {
+      return (
+        <div>
+          { this.renderInput(this.props) }
+          { this.renderNote(this.props) }
+        </div>
+      )
+    }
+
+    return this.renderInput(this.props)
+
   }
 }
 
@@ -139,6 +155,8 @@ Input.propTypes = {
    * Min value for the `input`. Should be used only when `type` is `number`.
    */
   min: PropTypes.number,
+  /** Form note for the input */
+  note: PropTypes.string,
   /**
    * Function that fires when the input loses focus. It fires regardless of
    * whether the value has changed.

--- a/src/components/Input/tests/index.js
+++ b/src/components/Input/tests/index.js
@@ -209,4 +209,13 @@ describe('components/Input', () => {
 
     expect(component.find('[data-test-section="foo-label"]').length).toBe(0);
   });
+
+  it('should render a note if passed', () => {
+    const component = mount(
+      <Input type="text" testSection="foo" note="A short description" />
+    );
+
+    expect(component.find('[data-test-section="foo-note"]').length).toBe(1);
+    expect(component.find('[data-test-section="foo-note"]').text()).toBe('A short description');
+  });
 });

--- a/src/components/Textarea/Textarea.story.js
+++ b/src/components/Textarea/Textarea.story.js
@@ -17,16 +17,36 @@ stories
   ));
 
 stories
-  .add('textarea with knobs', withInfo()(() => (<div>
-    <Textarea
-      isDisabled={ boolean('isDisabled', false) }
-      defaultValue='Delete this default value and see the placeholder'
-      placeholder={ text('placeHolder', 'Enter a comment') }
-      onBlur={ action('Textarea: onBlur') }
-      onChange={ action('Textarea: onChange') }
-      onFocus={ action('Textarea: onFocus') }
-      onInput={ action('Textarea: onInput') }
-      onKeyDown={ action('Textarea: onKeyDown') }
-    />
-  </div>)));
+  .add('textarea with knobs', withInfo()(() => {
+    return (
+      <div>
+        <Textarea
+          isDisabled={ boolean('isDisabled', false) }
+          defaultValue='Delete this default value and see the placeholder'
+          placeholder={ text('placeHolder', 'Enter a comment') }
+          onBlur={ action('Textarea: onBlur') }
+          onChange={ action('Textarea: onChange') }
+          onFocus={ action('Textarea: onFocus') }
+          onInput={ action('Textarea: onInput') }
+          onKeyDown={ action('Textarea: onKeyDown') }
+        />
+      </div>);
+  })).add('With label and note', () => {
+    return (
+      <Textarea
+        label="Field label"
+        note="A short description or note about this field."
+        placeholder="Just a placeholder"
+        type="text"
+      />);
+  }).add('Error state', () => {
+    return (
+      <Textarea
+        label="Field label"
+        displayError={ true }
+        note="A short description or note about this field."
+        placeholder="Just a placeholder"
+        type="text"
+      />);
+  });
 

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Label from '../Label';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
@@ -14,24 +15,25 @@ class Textarea extends React.Component {
     }
   }
 
-  render() {
-    const {
-      defaultValue,
-      isReadOnly,
-      isRequired,
-      isDisabled,
-      onBlur,
-      onChange,
-      onFocus,
-      onInput,
-      onKeyDown,
-      placeholder,
-      testSection,
-      value,
-    } = this.props;
-    const classes = classNames({
+  renderTextarea({
+    defaultValue,
+    displayError,
+    isReadOnly,
+    isRequired,
+    isDisabled,
+    onBlur,
+    onChange,
+    onFocus,
+    onInput,
+    onKeyDown,
+    placeholder,
+    testSection,
+    value,
+  }) {
+    const classes = classNames(
       'oui-textarea': true,
-    });
+      {'oui-form-bad-news': displayError},
+    );
 
     return (
       /* eslint-disable react/jsx-no-bind */
@@ -55,17 +57,75 @@ class Textarea extends React.Component {
       /* eslint-enable react/jsx-no-bind */
     );
   }
+
+  renderNote({note, testSection}) {
+    return (<div className='oui-form-note' data-test-section={ testSection && testSection + '-note' }>{note}</div>);
+  }
+
+  render() {
+    const {
+      label,
+      displayError,
+      testSection,
+      isOptional,
+      note,
+    } = this.props;
+
+    if (label) {
+      return (
+        <div
+          data-oui-component={ true }
+          className={ classNames({'oui-form-bad-news': displayError}) }>
+          <Label testSection={ testSection && testSection + '-label' }>
+            <div className="oui-label">
+              { label }
+              { isOptional && <span className="oui-label__optional">(Optional)</span> }
+            </div>
+            { this.renderTextarea(this.props) }
+          </Label>
+          { note && this.renderNote(this.props)}
+        </div>
+      );
+    }
+
+    if (note) {
+      return (
+        <div>
+          { this.renderTextarea(this.props) }
+          { this.renderNote(this.props) }
+        </div>
+      );
+    }
+
+    return this.renderTextarea(this.props);
+  }
 }
 
 Textarea.propTypes = {
   /** The default value of the textarea used on initial render */
   defaultValue: PropTypes.string,
+  /** Shows error styling if true */
+  displayError: PropTypes.bool,
   /** Prevents textarea from being modified and appears disabled */
   isDisabled: PropTypes.bool,
+  /** Adds an optional label if there is a label provided
+   *  @param {Object} props Object of props
+   *  @returns {Error} Error or null
+   */
+  isOptional: function verifyIsOptionalProp(props) {
+    if (props.isOptional && !props.label) {
+      return new Error('Must include a value for the label prop to use the isOptional prop');
+    }
+    return null;
+  },
   /** Prevents textarea from being modified but doesn't appear disabled */
   isReadOnly: PropTypes.bool,
   /** Prevents textarea from being submitted without value */
   isRequired: PropTypes.bool,
+  /** Text that describes the textarea */
+  label: PropTypes.string,
+  /** Form note for the input */
+  note: PropTypes.string,
   /**
     Function that fires when the textarea loses focus. It fires regardless of
     whether the value has changed.

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -89,12 +89,10 @@ class Textarea extends React.Component {
     }
 
     if (note) {
-      return (
-        <div>
-          { this.renderTextarea(this.props) }
-          { this.renderNote(this.props) }
-        </div>
-      );
+      return [
+        this.renderTextarea(this.props),
+        this.renderNote(this.props),
+      ];
     }
 
     return this.renderTextarea(this.props);
@@ -148,6 +146,13 @@ Textarea.propTypes = {
   testSection: PropTypes.string,
   /** Text within the textarea */
   value: PropTypes.string,
+};
+
+Textarea.defaultProps = {
+  displayError: false,
+  label: null,
+  note: null,
+  isOptional: false,
 };
 
 export default Textarea;

--- a/src/components/Textarea/tests/index.js
+++ b/src/components/Textarea/tests/index.js
@@ -106,4 +106,48 @@ describe('components/Textarea', () => {
 
     expect(component.is('[data-test-section="foo"]')).toBe(true);
   });
+
+  it('should render a label if label is passed', () => {
+    const component = mount(
+      <Textarea testSection="foo" label="Input Label" />
+    );
+
+    expect(component.find('[data-test-section="foo-label"]').length).toBe(1);
+  });
+
+  it('should render a label with optional text if label and isOptional is passed', () => {
+    const component = mount(
+      <Textarea testSection="foo" label="Input Label" isOptional={ true } />
+    );
+
+    expect(component.text()).toBe('Input Label(Optional)');
+  });
+
+  it('should throw an error if isOptional is passed without a label', () => {
+    spyOn(console, 'error').and.stub();
+
+    shallow(
+      <Textarea testSection="foo" isOptional={ true } />
+    );
+
+    expect(console.error.calls.all()[0].args[0]).toContain('Must include a value for the label prop to use the isOptional prop'); // eslint-disable-line
+  });
+
+
+  it('should not render a label by default', () => {
+    const component = mount(
+      <Textarea testSection="foo" />
+    );
+
+    expect(component.find('[data-test-section="foo-label"]').length).toBe(0);
+  });
+
+  it('should render a note if passed', () => {
+    const component = mount(
+      <Textarea testSection="foo" note="A short description" />
+    );
+
+    expect(component.find('[data-test-section="foo-note"]').length).toBe(1);
+    expect(component.find('[data-test-section="foo-note"]').text()).toBe('A short description');
+  });
 });


### PR DESCRIPTION
I'd like our form states to be more consistent, so I'm adding an optional note and label and note to input and textarea. This allows us to have consistent styling of these notes and of their error states. (Also it looks like we used to have a form note on input, based on the storybook options, but it may have gotten removed during the big refactor)

Input with label and note:
![image](https://user-images.githubusercontent.com/2287470/41932573-4b06d2ce-794f-11e8-959c-1839dfd03ee9.png)
Input with label and note and error state:
![image](https://user-images.githubusercontent.com/2287470/41932623-71da5be6-794f-11e8-871f-535e738c4826.png)


Textarea with label and note:
![image](https://user-images.githubusercontent.com/2287470/41932590-5548da52-794f-11e8-8d56-bf4e83f1cc25.png)
Textarea with label and note and error state:
![image](https://user-images.githubusercontent.com/2287470/41932606-614ee77e-794f-11e8-81d0-c3646f394ae6.png)
