### PR TITLE
Fixes #982 - Adds a tooltip component and story

### DIFF
--- a/src/components/Tooltip/Tooltip.story.js
+++ b/src/components/Tooltip/Tooltip.story.js
@@ -19,9 +19,11 @@ stories
   .add('default', withInfo()(() => (<div>
     <h3>
       I am an H3 with a tooltip next to it!
-      <Tooltip title="Help"
-               description="This is some help text to explain the thing next to whose
-                            question mark icon you are hovering over." />
+      <Tooltip
+        title="Help"
+        description="This is some help text to explain the thing next to whose
+                     question mark icon you are hovering over."
+      />
     </h3>
   </div>)))
   .add('nondefault', withInfo()(() => (<div>

--- a/src/components/Tooltip/Tooltip.story.js
+++ b/src/components/Tooltip/Tooltip.story.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import Tooltip from './index.js';
+
+const stories = storiesOf('Tooltip', module);
+stories
+  .addDecorator(withKnobs)
+  .addDecorator(story => (
+    <div id="root-preview">
+      {story()}
+    </div>
+  ));
+
+stories
+  .add('default', withInfo()(() => (<div>
+    <h3>
+      I am an H3 with a tooltip next to it!
+      <Tooltip title="Help" description="This is some help text to explain the thing next to whose question mark icon you are hovering over." />
+    </h3>
+  </div>)))
+  .add('nondefault', withInfo()(() => (<div>
+    <h3>
+      I am an H3 with a tooltip next to it <br />but with a differently positioned anchor arrow!
+      <Tooltip
+        title="Help"
+        description="This is some help text to explain the thing next to whose question mark icon you are hovering over."
+        horizontalAttachment={ 'center' }
+        verticalAttachment={ 'top' }
+      />
+    </h3>
+  </div>)))
+  .add('clickable poptip', withInfo()(() => (<div>
+    <h3>
+      Click my tip
+      <Tooltip
+        title="Help"
+        behavior="click"
+        description="You clicked."
+      />
+    </h3>
+  </div>)));

--- a/src/components/Tooltip/Tooltip.story.js
+++ b/src/components/Tooltip/Tooltip.story.js
@@ -19,7 +19,9 @@ stories
   .add('default', withInfo()(() => (<div>
     <h3>
       I am an H3 with a tooltip next to it!
-      <Tooltip title="Help" description="This is some help text to explain the thing next to whose question mark icon you are hovering over." />
+      <Tooltip title="Help"
+               description="This is some help text to explain the thing next to whose
+                            question mark icon you are hovering over." />
     </h3>
   </div>)))
   .add('nondefault', withInfo()(() => (<div>
@@ -27,7 +29,8 @@ stories
       I am an H3 with a tooltip next to it <br />but with a differently positioned anchor arrow!
       <Tooltip
         title="Help"
-        description="This is some help text to explain the thing next to whose question mark icon you are hovering over."
+        description="This is some help text to explain the thing next to whose question
+                     mark icon you are hovering over."
         horizontalAttachment={ 'center' }
         verticalAttachment={ 'top' }
       />

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -6,7 +6,8 @@ import OverlayWrapper from '../OverlayWrapper';
 import Popover from '../Popover';
 
 /**
- * Wrapper that combines OverlayWrapper, Popover, and Icon into one simple, elegant Tooltip!
+ * Wrapper that combines OverlayWrapper, Popover, and Icon into one simple,
+ * elegant Tooltip!
  * @param {Object} props - Properties passed to component
  * @returns {ReactElement}
  */
@@ -42,14 +43,14 @@ let Tooltip = ({
 };
 
 Tooltip.propTypes = {
-  /** Title of thing that is being described. */
-  title: PropTypes.string.isRequired,
-  /** Description of thing that the person hovered for. */
-  description: PropTypes.string.isRequired,
   /** Event to listen to and open the overlay */
   behavior: PropTypes.oneOf(['click', 'hover']),
+  /** Description of thing that the person hovered for. */
+  description: PropTypes.string.isRequired,
   /** Side of the `overlay` that should attach to the `children` */
   horizontalAttachment: PropTypes.oneOf(['left', 'center', 'right']),
+  /** Title of thing that is being described. */
+  title: PropTypes.string.isRequired,
   /** Vertical edge of the `overlay` that should touch the `children` */
   verticalAttachment: PropTypes.oneOf(['top', 'middle', 'bottom']),
 };
@@ -58,6 +59,6 @@ Tooltip.defaultProps = {
   behavior: 'hover',
   horizontalAttachment: 'left',
   verticalAttachment: 'middle',
-}
+};
 
 export default Tooltip;

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Icon from 'react-oui-icons';
+import OverlayWrapper from '../OverlayWrapper';
+import Popover from '../Popover';
+
+/**
+ * Wrapper that combines OverlayWrapper, Popover, and Icon into one simple, elegant Tooltip!
+ * @param {Object} props - Properties passed to component
+ * @returns {ReactElement}
+ */
+let Tooltip = ({
+  title,
+  description,
+  behavior,
+  horizontalAttachment,
+  verticalAttachment,
+}) => {
+  return (
+    <OverlayWrapper
+      behavior={ behavior }
+      horizontalAttachment={ horizontalAttachment }
+      verticalAttachment={ verticalAttachment }
+      overlay={
+        <Popover title={ title }>
+          <p>
+            { description }
+          </p>
+        </Popover>
+      }>
+      <span
+        className="cursor--pointer"
+        style={{marginBottom: '-1px', marginLeft: '6px', marginTop: '3px'}}>
+        <Icon
+          name="help"
+          size="small"
+        />
+      </span>
+    </OverlayWrapper>
+  );
+};
+
+Tooltip.propTypes = {
+  /** Title of thing that is being described. */
+  title: PropTypes.string.isRequired,
+  /** Description of thing that the person hovered for. */
+  description: PropTypes.string.isRequired,
+  /** Event to listen to and open the overlay */
+  behavior: PropTypes.oneOf(['click', 'hover']),
+  /** Side of the `overlay` that should attach to the `children` */
+  horizontalAttachment: PropTypes.oneOf(['left', 'center', 'right']),
+  /** Vertical edge of the `overlay` that should touch the `children` */
+  verticalAttachment: PropTypes.oneOf(['top', 'middle', 'bottom']),
+};
+
+Tooltip.defaultProps = {
+  behavior: 'hover',
+  horizontalAttachment: 'left',
+  verticalAttachment: 'middle',
+}
+
+export default Tooltip;


### PR DESCRIPTION
This diff addresses #982 . Currently, we are making Tooltips in the app in a REALLY yucky way.

Here's a tooltip:
![image](https://user-images.githubusercontent.com/729524/42121368-8ef48022-7be2-11e8-8499-5c9b0d7f1788.png)

And here's the code we are using to create them in React:
```
                <OverlayWrapper
                  behavior='hover'
                  horizontalAttachment='left'
                  horizontalTargetAttachment='right'
                  verticalAttachment='middle'
                  verticalTargetAttachment='middle'
                  overlay={
                    <Popover title={ tr('Environment Key') }>
                      <p>
                        { this.props.keyInputTooltipText }
                      </p>
                    </Popover>
                  }>
                  <span
                    className="cursor--pointer"
                    style={{marginBottom: '-1px', marginLeft: '6px', marginTop: '3px'}}>
                    <Icon
                      name="help"
                      size="small"
                    />
                  </span>
                </OverlayWrapper>
```

This is a WIP/Friday night project, definitely open to feedback/suggestions! 