### PR TITLE
Fixes #984 - Add HelpPopover component to OUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 
 ## Unreleased
 
+## 31.6.3 - 2018-07-06
+#### Added
+- [Feature] Added HelpPopover component
+
 ## 31.6.2 - 2018-07-05
 ### Added
 - [Feature] Added note to Input 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 ## Unreleased
 
 ## 31.6.3 - 2018-07-06
-#### Added
-- [Feature] Added HelpPopover component
+#### Added 
+- [Feature] Added HelpPopover component (#984)
 
 ## 31.6.2 - 2018-07-05
 ### Added

--- a/src/components/HelpPopover/HelpPopover.story.js
+++ b/src/components/HelpPopover/HelpPopover.story.js
@@ -16,21 +16,19 @@ stories
   ));
 
 stories
-  .add('default', withInfo()(() => (<div>
-    <div className="position--relative height--100 text--center">
-      <HelpPopover popoverTitle="This is a popover title">
-        <p>
-          This is a popover description. 🤓
-        </p>
-      </HelpPopover>
-    </div>
-  </div>)))
+  .add('default', withInfo()(() => (
+    <HelpPopover popoverTitle="This is a popover title">
+      This is a popover description. 🤓
+    </HelpPopover>
+  )))
   .add('hover', withInfo()(() => (<div>
     <div className="position--relative height--100 text--center">
-      <HelpPopover popoverTitle="This is a popover title" behavior="hover">
-        <p>
-         You hovered! 🤓
-        </p>
+      <HelpPopover
+        popoverTitle="This is a popover title"
+        behavior="hover"
+        horizontalAttachment="left"
+        verticalAttachment="middle">
+       You hovered! 🤓
       </HelpPopover>
     </div>
   </div>)));

--- a/src/components/HelpPopover/HelpPopover.story.js
+++ b/src/components/HelpPopover/HelpPopover.story.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import HelpPopover from './index.js';
+
+const stories = storiesOf('HelpPopover', module);
+stories
+  .addDecorator(withKnobs)
+  .addDecorator(story => (
+    <div id="root-preview">
+      {story()}
+    </div>
+  ));
+
+stories
+  .add('default', withInfo()(() => (<div>
+    <div className="position--relative height--100 text--center">
+      <HelpPopover popoverTitle="This is a popover title">
+        <p>
+          This is a popover description. 🤓
+        </p>
+      </HelpPopover>
+    </div>
+  </div>)))
+  .add('hover', withInfo()(() => (<div>
+    <div className="position--relative height--100 text--center">
+      <HelpPopover popoverTitle="This is a popover title" behavior="hover">
+        <p>
+         You hovered! 🤓
+        </p>
+      </HelpPopover>
+    </div>
+  </div>)));

--- a/src/components/HelpPopover/index.js
+++ b/src/components/HelpPopover/index.js
@@ -58,8 +58,6 @@ HelpPopover.propTypes = {
 
 HelpPopover.defaultProps = {
   behavior: 'click',
-  horizontalAttachment: 'center',
-  verticalAttachment: 'top',
   iconSize: 'medium',
   isConstrainedToScreen: true,
   testSection: 'help-popover',

--- a/src/components/HelpPopover/index.js
+++ b/src/components/HelpPopover/index.js
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import OverlayWrapper from '../OverlayWrapper';
+import Popover from '../Popover';
+import Icon from 'react-oui-icons';
+
+const HelpPopover = ({
+  behavior,
+  children,
+  horizontalAttachment,
+  iconSize,
+  isConstrainedToScreen,
+  popoverTitle,
+  verticalAttachment,
+  testSection,
+}) => (
+  <OverlayWrapper
+    behavior={ behavior }
+    horizontalAttachment={ horizontalAttachment }
+    isConstrainedToScreen={ isConstrainedToScreen }
+    overlay={
+      <Popover title={ popoverTitle }>
+        { children }
+      </Popover>
+    }
+    testSection={ testSection }
+    verticalAttachment={ verticalAttachment }>
+    <span
+      className="cursor--pointer push-half--left"
+      style={{'marginBottom': '1px'}}
+      data-test-section="help-popover-icon">
+      <Icon
+        name="help"
+        size={ iconSize }
+      />
+    </span>
+  </OverlayWrapper>
+);
+
+HelpPopover.propTypes = {
+  /** Event to listen to and open the overlay */
+  behavior: PropTypes.oneOf(['click', 'hover']),
+  /** Description of thing that the person hovered for. */
+  children: PropTypes.node.isRequired,
+  /** Side of the `overlay` that should attach to the `children` */
+  horizontalAttachment: PropTypes.oneOf(['left', 'center', 'right']),
+  /** Size of icon */
+  iconSize: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** Attach `overlay` to an edge of the screen if it is going to move off */
+  isConstrainedToScreen: PropTypes.bool,
+  /** Title of thing that is being described. */
+  popoverTitle: PropTypes.string,
+  /** Test section */
+  testSection: PropTypes.string,
+  /** Vertical edge of the `overlay` that should touch the `children` */
+  verticalAttachment: PropTypes.oneOf(['top', 'middle', 'bottom']),
+};
+
+HelpPopover.defaultProps = {
+  behavior: 'click',
+  horizontalAttachment: 'center',
+  verticalAttachment: 'top',
+  iconSize: 'medium',
+  isConstrainedToScreen: true,
+  testSection: 'help-popover',
+};
+
+export default HelpPopover;

--- a/src/components/HelpPopover/tests/__snapshots__/index.js.snap
+++ b/src/components/HelpPopover/tests/__snapshots__/index.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/HelpPopover renders correctly 1`] = `
+<OverlayWrapper
+  behavior="click"
+  horizontalAttachment="center"
+  isConstrainedToScreen={true}
+  overlay={
+    <Popover
+      padding="default"
+      title="I am a popover title!"
+    >
+      I am a popover description.
+    </Popover>
+  }
+  shouldHideOnClick={true}
+  testSection="help-popover"
+  verticalAttachment="top"
+>
+  <span
+    className="cursor--pointer push-half--left"
+    data-test-section="help-popover-icon"
+    style={
+      Object {
+        "marginBottom": "1px",
+      }
+    }
+  >
+    <Icon
+      name="help"
+      size="medium"
+    />
+  </span>
+</OverlayWrapper>
+`;

--- a/src/components/HelpPopover/tests/index.js
+++ b/src/components/HelpPopover/tests/index.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import HelpPopover from '../index.js';
+import { mount, shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
+
+describe.only('components/HelpPopover', () => {
+  it('renders correctly', () => {
+    const component = shallow(<HelpPopover popoverTitle="I am a popover title!">I am a popover description.</HelpPopover>);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  it('should render text passed in as children and with default props', function() {
+    const message = 'Hello! This is a short popover with no title, just the defaults.';
+    const component = mount(
+      <HelpPopover>{ message }</HelpPopover>
+    );
+    const overlayWrapper = component.find('OverlayWrapper');
+    expect(overlayWrapper.length).toBe(1);
+    expect(overlayWrapper.props().behavior).toBe('click');
+    expect(overlayWrapper.props().isConstrainedToScreen).toBe(true);
+    expect(overlayWrapper.props().testSection).toBe('help-popover');
+
+    const popover = component.find('Popover');
+    expect(popover.length).toBe(1);
+    expect(popover.props().title).toBe(undefined);
+    expect(popover.props().children).toBe(message);
+  });
+
+  it('should render custom props properly', function() {
+    const child = (
+      <p>
+        I am some random popover content. 🤓
+      </p>
+    );
+
+    const component = mount(
+      <HelpPopover
+        behavior="hover"
+        testSection="custom-test-section"
+        popoverTitle="I am a title">
+        { child }
+      </HelpPopover>
+    );
+    const overlayWrapper = component.find('OverlayWrapper');
+    expect(overlayWrapper.length).toBe(1);
+    expect(overlayWrapper.props().behavior).toBe('hover');
+
+    const popover = component.find('Popover');
+    expect(popover.length).toBe(1);
+    expect(popover.props().title).toBe('I am a title');
+    expect(popover.props().children).toBe(child);
+  });
+});


### PR DESCRIPTION
This diff adds a HelpPopover to the OUI component library; the next step would be to [move it out of react_components](https://github.com/optimizely/optimizely/blob/da1463f6f8fff3847e8a457d909d3a647cadd8da/src/www/frontend/src/js/react_components/help_popover/index.js). @alansun-optimizely 