### PR TITLE
Remove SelectDropdown filter functionality, and revert Dropdown components to before PR #961

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+### Fixed
+- [Patch] Undo breaking changes to Dropdown, remove filter functionality from SelectDropdown that required Dropdown's breaking changes
 
 ## 31.7.1 - 2018-07-09
 ### Fixed

--- a/src/components/Dropdown/Dropdown.story.js
+++ b/src/components/Dropdown/Dropdown.story.js
@@ -8,6 +8,7 @@ import { withInfo } from '@storybook/addon-info';
 
 import Dropdown from './index.js';
 import Button from '../Button';
+import BlockList from '../BlockList';
 import Icon from 'react-oui-icons';
 
 const data = [
@@ -33,20 +34,24 @@ stories.add('Default', withInfo()(() => {
         buttonContent='Default Dropdown'
         width={ number('width', 300) }
         arrowIcon={ true }>
-        <Dropdown.Contents>
+        <BlockList>
           {
             data.map((item, index) => {
               return (
-                <Dropdown.ListItem key={ index }>
-                  <Dropdown.BlockLink onClick={ action('click on complex item') }>
-                    <Dropdown.BlockLinkText text={ item.title } />
-                    <Dropdown.BlockLinkSecondaryText secondaryText={ item.description } />
-                  </Dropdown.BlockLink>
-                </Dropdown.ListItem>
+                <BlockList.Category header={ item.header } key={ index }>
+                  <BlockList.Item onClick={ action('click on complex item') }>
+                    <div className="flex flex-align--center">
+                      <div className="flex--1">
+                        <div>{ item.title }</div>
+                        <div className="muted micro">{ item.description }</div>
+                      </div>
+                    </div>
+                  </BlockList.Item>
+                </BlockList.Category>
               );
             })
           }
-        </Dropdown.Contents>
+        </BlockList>
       </Dropdown>
     </Container>
   );
@@ -60,20 +65,24 @@ stories.add('Error', withInfo()(() => {
         width={ number('width', 300) }
         displayError={ true }
         arrowIcon={ true }>
-        <Dropdown.Contents>
+        <BlockList>
           {
             data.map((item, index) => {
               return (
-                <Dropdown.ListItem key={ index }>
-                  <Dropdown.BlockLink onClick={ action('click on complex item') }>
-                    <Dropdown.BlockLinkText text={ item.title } />
-                    <Dropdown.BlockLinkSecondaryText secondaryText={ item.description } />
-                  </Dropdown.BlockLink>
-                </Dropdown.ListItem>
+                <BlockList.Category header={ item.header } key={ index }>
+                  <BlockList.Item onClick={ action('click on complex item') }>
+                    <div className="flex flex-align--center">
+                      <div className="flex--1">
+                        <div>{ item.title }</div>
+                        <div className="muted micro">{ item.description }</div>
+                      </div>
+                    </div>
+                  </BlockList.Item>
+                </BlockList.Category>
               );
             })
           }
-        </Dropdown.Contents>
+        </BlockList>
       </Dropdown>
     </Container>
   );
@@ -87,20 +96,24 @@ stories.add('Icon', withInfo()(() => {
         fullWidth={ boolean('fullWidth', false) }
         buttonContent={ <div>Hamburgers <span className="push-half--left"><Icon name='hamburger' /></span></div> }
         width={ number('width', 350) }>
-        <Dropdown.Contents>
+        <BlockList>
           {
             data.map((item, index) => {
               return (
-                <Dropdown.ListItem key={ index }>
-                  <Dropdown.BlockLink onClick={ action('click on complex item') }>
-                    <Dropdown.BlockLinkText text={ item.title } />
-                    <Dropdown.BlockLinkSecondaryText secondaryText={ item.description } />
-                  </Dropdown.BlockLink>
-                </Dropdown.ListItem>
+                <BlockList.Category header={ item.header } key={ index }>
+                  <BlockList.Item onClick={ action('click on complex item') }>
+                    <div className="flex flex-align--center">
+                      <div className="flex--1">
+                        <div>{ item.title }</div>
+                        <div className="muted micro">{ item.description }</div>
+                      </div>
+                    </div>
+                  </BlockList.Item>
+                </BlockList.Category>
               );
             })
           }
-        </Dropdown.Contents>
+        </BlockList>
       </Dropdown>
     </Container>
   );
@@ -115,22 +128,24 @@ stories.add('Z-index', withInfo()(() => {
             isDisabled={ boolean('isDisabled', false) }
             buttonContent='Dropdown'
             width={ number('width', 300) }>
-            <Dropdown.Contents
-              minWidth={ 300 }
-              direction={ 'up' }>
+            <BlockList>
               {
                 data.map((item, index) => {
                   return (
-                    <Dropdown.ListItem key={ index }>
-                      <Dropdown.BlockLink onClick={ action('click on complex item') }>
-                        <Dropdown.BlockLinkText text={ item.title } />
-                        <Dropdown.BlockLinkSecondaryText secondaryText={ item.description } />
-                      </Dropdown.BlockLink>
-                    </Dropdown.ListItem>
+                    <BlockList.Category header={ item.header } key={ index }>
+                      <BlockList.Item onClick={ action('click on complex item') }>
+                        <div className="flex flex-align--center">
+                          <div className="flex--1">
+                            <div>{ item.title }</div>
+                            <div className="muted micro">{ item.description }</div>
+                          </div>
+                        </div>
+                      </BlockList.Item>
+                    </BlockList.Category>
                   );
                 })
               }
-            </Dropdown.Contents>
+            </BlockList>
           </Dropdown>
           <h1>This text should be behind the open dropdown</h1>
         </ScrollContainer>

--- a/src/components/Dropdown/DropdownContents/index.js
+++ b/src/components/Dropdown/DropdownContents/index.js
@@ -25,13 +25,7 @@ export default function DropdownContents(props) {
       className={ classes }
       style={ styleProps }
       { ...(props.testSection ? { 'data-test-section': props.testSection } : {}) }>
-      {
-        React.Children.map(props.children, (child) => {
-          return child && React.cloneElement(child, {
-            handleToggle: props.handleToggle,
-          });
-        })
-      }
+      { props.children }
     </ul>
   );
 }
@@ -43,11 +37,6 @@ DropdownContents.propTypes = {
   children: PropTypes.node.isRequired,
   /** Direction of contents */
   direction: PropTypes.oneOf(['left', 'right', 'up']),
-  /**
-   * Function passed to children to determine
-   * if dropdown should be hidden
-   */
-  handleToggle: PropTypes.func,
   /** Whether to wrap contents or not */
   isNoWrap: PropTypes.bool,
   /** Minimum width of contents */
@@ -62,7 +51,6 @@ DropdownContents.propTypes = {
 DropdownContents.defaultProps = {
   canScroll: false,
   direction: 'left',
-  handleToggle: () => {},
   isNoWrap: false,
   testSection: '',
 };

--- a/src/components/Dropdown/DropdownContents/tests/index.js
+++ b/src/components/Dropdown/DropdownContents/tests/index.js
@@ -4,47 +4,47 @@ import { shallow } from 'enzyme';
 
 describe('components/Dropdown/DropdownContents', () => {
   it('should render as a `ul`', () => {
-    const component = shallow(<DropdownContents><div>foo</div></DropdownContents>);
+    const component = shallow(<DropdownContents></DropdownContents>);
     expect(component.type()).toBe('ul');
   });
 
   it('should render children', () => {
-    const component = shallow(<DropdownContents><div>foo</div></DropdownContents>);
+    const component = shallow(<DropdownContents><li>foo</li></DropdownContents>);
     expect(component.text()).toBe('foo');
   });
 
   it('should render with test section', () => {
-    const component = shallow(<DropdownContents testSection="goose"><div>foo</div></DropdownContents>);
+    const component = shallow(<DropdownContents testSection="goose"></DropdownContents>);
     expect(component.is('[data-test-section="goose"]')).toBe(true);
   });
 
   it('should render with nowrap', () => {
-    const component = shallow(<DropdownContents isNoWrap={ true }><div>foo</div></DropdownContents>);
+    const component = shallow(<DropdownContents isNoWrap={ true }></DropdownContents>);
     expect(component.find('ul').prop('className')).toBe('nowrap oui-dropdown oui-dropdown--right');
   });
 
   it('should render with default direction left', () => {
-    const component = shallow(<DropdownContents><div>foo</div></DropdownContents>);
+    const component = shallow(<DropdownContents></DropdownContents>);
     expect(component.find('ul').prop('className')).toBe('oui-dropdown oui-dropdown--right');
   });
 
   it('should render with direction right', () => {
-    const component = shallow(<DropdownContents direction={ 'right' }><div>foo</div></DropdownContents>);
+    const component = shallow(<DropdownContents direction={ 'right' }></DropdownContents>);
     expect(component.find('ul').prop('className')).toBe('oui-dropdown');
   });
 
   it('should render with direction up', () => {
-    const component = shallow(<DropdownContents direction={ 'up' }><div>foo</div></DropdownContents>);
+    const component = shallow(<DropdownContents direction={ 'up' }></DropdownContents>);
     expect(component.find('ul').prop('className')).toBe('oui-dropdown oui-dropdown--up');
   });
 
   it('should render with a minimum width', () => {
-    const component = shallow(<DropdownContents minWidth={ '300px' }><div>foo</div></DropdownContents>);
+    const component = shallow(<DropdownContents minWidth={ '300px' }></DropdownContents>);
     expect(component.find('ul').prop('style')).toEqual({ minWidth: '300px' });
   });
 
   it('should render with scroll styles if canScroll', () => {
-    const component = shallow(<DropdownContents canScroll={ true }><div>foo</div></DropdownContents>);
+    const component = shallow(<DropdownContents canScroll={ true }></DropdownContents>);
     expect(component.find('ul').prop('style')).toEqual({ overflowY: 'visible', maxHeight: 'auto' });
   });
 });

--- a/src/components/Dropdown/DropdownListItem/index.js
+++ b/src/components/Dropdown/DropdownListItem/index.js
@@ -3,22 +3,16 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 export default function DropdownListItem(props) {
-  function onClick() {
-    if (props.hideOnClick) {
-      props.handleToggle();
-    }
-  }
-
   const classes = classNames({
     'hard--sides': props.hardSides,
     'hard--top': props.hardTop,
     'oui-dropdown__item': true,
   });
 
+
   return (
     <li
-      className={ classes }
-      onClick={ onClick }>
+      className={ classes }>
       { props.children }
     </li>
   );
@@ -27,16 +21,8 @@ export default function DropdownListItem(props) {
 DropdownListItem.propTypes = {
   /** Nodes to display within */
   children: PropTypes.node,
-  /** Function to toggle visibility of Dropdown.Contents */
-  handleToggle: PropTypes.func,
   /** Remove padding from sides */
   hardSides: PropTypes.bool,
   /** Remove padding from top */
   hardTop: PropTypes.bool,
-  /** Whether to hide Dropdown.Contents when the item is clicked or not */
-  hideOnClick: PropTypes.bool,
-};
-
-DropdownListItem.defaultProps = {
-  hideOnClick: true,
 };

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -116,12 +116,9 @@ class Dropdown extends React.Component {
             boxShadow: '0 2px 3px rgba(0,0,0,.1)',
           }}
           onMouseOver={ this.onMouseOver }
-          onMouseLeave={ this.onMouseLeave }>
-          { isOpen && !isDisabled && React.Children.map(children, (child) => {
-            return child && React.cloneElement(child, {
-              handleToggle: this.handleToggle,
-            });
-          }) }
+          onMouseLeave={ this.onMouseLeave }
+          onClick={ this.handleToggle }>
+          { isOpen && !isDisabled && children }
         </Popper>
       </Manager>
     );

--- a/src/components/Dropdown/tests/__snapshots__/index.js.snap
+++ b/src/components/Dropdown/tests/__snapshots__/index.js.snap
@@ -36,25 +36,7 @@ exports[`components/Dropdown should include oui-form-bad-news class when display
   displayError={true}
   isOpen={false}
   toggle={[Function]}
->
-  <ul>
-    <li
-      key="0"
-    >
-      Manual
-    </li>
-    <li
-      key="1"
-    >
-      Maximize Conventions
-    </li>
-    <li
-      key="2"
-    >
-      Faster Results
-    </li>
-  </ul>
-</withHandlers(withState(Dropdown))>
+/>
 `;
 
 exports[`components/Dropdown should not render children when isDisabled is true 1`] = `
@@ -125,25 +107,7 @@ exports[`components/Dropdown should render an activator node when passed as a pr
   displayError={true}
   isOpen={false}
   toggle={[Function]}
->
-  <ul>
-    <li
-      key="0"
-    >
-      Manual
-    </li>
-    <li
-      key="1"
-    >
-      Maximize Conventions
-    </li>
-    <li
-      key="2"
-    >
-      Faster Results
-    </li>
-  </ul>
-</withHandlers(withState(Dropdown))>
+/>
 `;
 
 exports[`components/Dropdown should render children when isOpen is true 1`] = `

--- a/src/components/Dropdown/tests/index.js
+++ b/src/components/Dropdown/tests/index.js
@@ -136,14 +136,6 @@ describe('components/Dropdown', () => {
       <Dropdown
         buttonContent='Dropdown'
         displayError={ true }>
-        <ul>
-          { data.map((item, index) => {
-            return (
-              <li key={ index }>{ item.title }</li>
-            );
-          })
-          }
-        </ul>
       </Dropdown>
     );
     expect(shallowToJson(component)).toMatchSnapshot();
@@ -154,14 +146,6 @@ describe('components/Dropdown', () => {
       <Dropdown
         activator={ <button>Click me</button> }
         displayError={ true }>
-        <ul>
-          { data.map((item, index) => {
-            return (
-              <li key={ index }>{ item.title }</li>
-            );
-          })
-          }
-        </ul>
       </Dropdown>
     );
     expect(shallowToJson(component)).toMatchSnapshot();

--- a/src/components/SelectDropdown/SelectDropdown.story.js
+++ b/src/components/SelectDropdown/SelectDropdown.story.js
@@ -53,20 +53,6 @@ stories.add('default', withInfo()(() => {
   );
 }));
 
-stories.add('filter', withInfo()(() => {
-  return (
-    <Container>
-      <SelectDropdown
-        items={ items }
-        value={ 'dog' }
-        onChange={ action('SelectDropdown value changed') }
-        isFilterable={ true }
-        width={ '400px ' }
-      />
-    </Container>
-  );
-}));
-
 const Container = styled.div`
   display: flex;
   flex: 1;

--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { isFilterTermInItem } from '../../utils/filter';
 
 import Button from '../Button';
-import Input from '../Input';
 import Dropdown from '../Dropdown';
 
 
@@ -18,18 +16,9 @@ class SelectDropdown extends React.Component {
      */
     dropdownDirection: PropTypes.oneOf(['right', 'left']),
     /**
-     * Placeholder text for the filter input.
-     */
-    inputPlaceholder: PropTypes.string,
-    /**
      * The select is greyed out if it is disabled.
      */
     isDisabled: PropTypes.bool,
-    /**
-     * Boolean that determines whether or
-     * not the selector has the filter feature.
-     */
-    isFilterable: PropTypes.bool,
     /**
      * Dropdown items that can be selected from the select dropdown.
      */
@@ -86,49 +75,18 @@ class SelectDropdown extends React.Component {
   static defaultProps = {
     buttonStyle: 'outline',
     inputPlaceholder: '',
-    isFilterable: false,
     dropdownDirection: 'right',
     width: '100%',
     trackId: '',
     testSection: '',
   };
 
-  state = {
-    searchTerm: '',
-  };
-
-  search = (event) => {
-    this.setState({
-      searchTerm: event.target.value,
-    });
-  };
-
-  filterTermValue = (value) => {
-    return isFilterTermInItem(this.state.searchTerm, value);
-  };
-
   renderContents = () => {
-    const { items, value, minDropdownWidth, dropdownDirection, isFilterable, inputPlaceholder } = this.props;
-    const itemsToDisplay = items.filter(item => {
-      return this.filterTermValue(item.label);
-    });
+    const { items, value, minDropdownWidth, dropdownDirection } = this.props;
 
     return (
       <Dropdown.Contents minWidth={ minDropdownWidth } direction={ dropdownDirection }>
-        { isFilterable && (
-          <Dropdown.ListItem hideOnClick={ false }>
-            <form className="soft-half--ends oui-search">
-              <Input
-                type="text"
-                isFilter={ true }
-                value={ this.state.searchTerm }
-                placeholder={ inputPlaceholder }
-                onChange={ this.search }
-              />
-            </form>
-          </Dropdown.ListItem>
-        )}
-        { itemsToDisplay.map((entry, index) => (
+        { items.map((entry, index) => (
           <SelectOption
             key={ index }
             onChange={ this.props.onChange }

--- a/src/components/SelectDropdown/tests/index.js
+++ b/src/components/SelectDropdown/tests/index.js
@@ -25,7 +25,7 @@ describe('components/SelectDropdown', function() {
 
   describe('without a filter', function() {
     beforeEach(function() {
-      component = mount(<SelectDropdown isFilterable={ false } items={ items } value={ 'value 2' } onChange={ onChange } />);
+      component = mount(<SelectDropdown items={ items } value={ 'value 2' } onChange={ onChange } />);
     });
 
     it('should render all items in dropdown', function() {
@@ -53,35 +53,6 @@ describe('components/SelectDropdown', function() {
       item1.simulate('click');
       expect(onChange).toHaveBeenCalled();
       expect(onChange).toHaveBeenCalledWith('value 1');
-    });
-
-    it('should not add an input if isFilterable is false', function() {
-      const activator = component.find('Button');
-      activator.simulate('click');
-      const input = component.find('Input');
-      expect(input).toHaveLength(0);
-    });
-  });
-
-  describe('with a filter', function() {
-    beforeEach(function() {
-      component = mount(<SelectDropdown isFilterable={ true } items={ items } value={ 'value 2' } onChange={ onChange } />);
-    });
-    it('should filter items in dropdown', function() {
-      const activator = component.find('Button');
-      activator.simulate('click');
-      const input = component.find('Input');
-      input.simulate('change', {target: {value: '1'}});
-
-      const listItems = component.find('SelectOption');
-      expect(listItems).toHaveLength(1);
-
-      const item1 = listItems.at(0);
-      expect(item1.text()).toContain('label 1');
-      expect(item1.text()).toContain('description 1');
-
-      input.simulate('change', {target: {value: 'INVALID_VALUE'}});
-      expect(component.find('SelectOption')).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
I accidentally made a breaking change that was not recorded as a breaking change, by changing the guts of how Dropdown works. To unblock other changes needed in OUI in optimizely.git, I'm reverting the changes that required the breaking changes to Dropdown, and removing the ability to filter in a SelectDropdown for the time being.

More context:
The current expected functionality of Dropdown is that if the user clicks on anything in the Popover of the Dropdown, the Dropdown's Popover will be hidden. The changes in https://github.com/optimizely/oui/pull/961 made it so that the Dropdown Popover would only be hidden if a DropdownListItem was clicked - this was so that we could include in input field in SelectDropdown to be able to filter the items shown in the Popover - with current functionality, clicking in the input would mean the Popover would close.

This filter functionality should be reimplemented soon, when others are not blocked by these changes.

To revert the dropdown changes, I ran `git checkout 069febceeff65e3c31de29e2a35eb505f445c3d7 src/Components/Dropdown` (This is the commit hash for the PR where I added subcomponents to Dropdown: https://github.com/optimizely/oui/commit/069febceeff65e3c31de29e2a35eb505f445c3d7)