### PR TITLE
Drau/port x dashboardtabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+### Added
+- [Feature] Add <TabNav style=dashboard> style ported from X (#989)
 
 ## 31.7.2 - 2018-07-11
 ### Fixed

--- a/src/components/TabNav/TabNav.story.js
+++ b/src/components/TabNav/TabNav.story.js
@@ -18,65 +18,17 @@ stories
 
 stories
   .add('Dashboard tabs', withInfo()(() => (
-    <div className="root-wrap">
-      <div className="wrap">
-        <ul className="root-nav root-nav--open" data-test-section="p13n-root-navbar">
-          <li className="root-nav__logo push-double--bottom">
-            <a href="/v2/projects">
-              <div className="root-nav__logo--mark"></div>
-              <div className="root-nav__logo--full"></div>
-            </a>
-          </li>
-          <li className="push-double--ends">
-            <ul>
-              <li data-test-section="personalization-nav-tab">
-                <a href="/v2/projects/4576166120" className="root-nav__link root-nav__link--primary is-active">
-                  <svg className="root-nav__icon root-nav__icon--large">
-                  </svg>
-                  <div className="root-nav__link__text">
-                    Rootnav Item
-                  </div>
-                </a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-        <div className="root-panel">
-          <div className="stage">
-            <div className="stage__item__content--column position--relative">
-              <div className="stage">
-                <div className="stage__item">
-                  <div className="stage__item__content--column">
-                    <div className="stage__item__content--column">
-                      <div className="push-quad--sides push-double--top flex--none" data-test-section="campaigns-root">
-                        <div className="muted" data-test-section="campaigns-root-project-name">Project Name</div>
-                        <div className="beta push--bottom">Experiments</div>
-
-                          <TabNav activeTab="second" style={ ['dashboard'] }>
-                            <TabNav.Tab onClick={ action('first tab clicked') } tabId="first">
-                              Tab #1
-                            </TabNav.Tab>
-                            <TabNav.Tab onClick={ action('second tab clicked') } tabId="second">
-                              Tab #2
-                            </TabNav.Tab>
-                            <TabNav.Tab onClick={ action('third tab clicked') } tabId="third">
-                              Tab #3
-                            </TabNav.Tab>
-                          </TabNav>
-
-                        </div>
-                        <div className="flex flex--1" data-test-section="layers-table-container">
-                          <div className="flex flex--1 flex--column"></div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <TabNav activeTab="second" style={ ['dashboard'] }>
+      <TabNav.Tab onClick={ action('first tab clicked') } tabId="first">
+        Tab #1
+      </TabNav.Tab>
+      <TabNav.Tab onClick={ action('second tab clicked') } tabId="second">
+        Tab #2
+      </TabNav.Tab>
+      <TabNav.Tab onClick={ action('third tab clicked') } tabId="third">
+        Tab #3
+      </TabNav.Tab>
+    </TabNav>
   )))
   .add('Basic tabs', withInfo()(() => (
     <TabNav activeTab="first">

--- a/src/components/TabNav/TabNav.story.js
+++ b/src/components/TabNav/TabNav.story.js
@@ -17,7 +17,68 @@ stories
   ));
 
 stories
-  .add('basic tabs', withInfo()(() => (<div>
+  .add('Dashboard tabs', withInfo()(() => (
+    <div className="root-wrap">
+      <div className="wrap">
+        <ul className="root-nav root-nav--open" data-test-section="p13n-root-navbar">
+          <li className="root-nav__logo push-double--bottom">
+            <a href="/v2/projects">
+              <div className="root-nav__logo--mark"></div>
+              <div className="root-nav__logo--full"></div>
+            </a>
+          </li>
+          <li className="push-double--ends">
+            <ul>
+              <li data-test-section="personalization-nav-tab">
+                <a href="/v2/projects/4576166120" className="root-nav__link root-nav__link--primary is-active">
+                  <svg className="root-nav__icon root-nav__icon--large">
+                  </svg>
+                  <div className="root-nav__link__text">
+                    Rootnav Item
+                  </div>
+                </a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <div className="root-panel">
+          <div className="stage">
+            <div className="stage__item__content--column position--relative">
+              <div className="stage">
+                <div className="stage__item">
+                  <div className="stage__item__content--column">
+                    <div className="stage__item__content--column">
+                      <div className="push-quad--sides push-double--top flex--none" data-test-section="campaigns-root">
+                        <div className="muted" data-test-section="campaigns-root-project-name">Project Name</div>
+                        <div className="beta push--bottom">Experiments</div>
+
+                          <TabNav activeTab="second" style={ ['dashboard'] }>
+                            <TabNav.Tab onClick={ action('first tab clicked') } tabId="first">
+                              Tab #1
+                            </TabNav.Tab>
+                            <TabNav.Tab onClick={ action('second tab clicked') } tabId="second">
+                              Tab #2
+                            </TabNav.Tab>
+                            <TabNav.Tab onClick={ action('third tab clicked') } tabId="third">
+                              Tab #3
+                            </TabNav.Tab>
+                          </TabNav>
+
+                        </div>
+                        <div className="flex flex--1" data-test-section="layers-table-container">
+                          <div className="flex flex--1 flex--column"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )))
+  .add('Basic tabs', withInfo()(() => (
     <TabNav activeTab="first">
       <TabNav.Tab onClick={ action('first tab clicked') } tabId="first">
         Tab #1
@@ -29,8 +90,8 @@ stories
         Tab #3
       </TabNav.Tab>
     </TabNav>
-  </div>)))
-  .add('closed tabs', withInfo()(() => (<div>
+  )))
+  .add('Closed tabs', withInfo()(() => (
     <TabNav activeTab="second" style={ ['small'] }>
       <TabNav.Tab onClick={ action('first tab clicked') } tabId="first">
         Tab #1
@@ -42,8 +103,8 @@ stories
         Tab #3
       </TabNav.Tab>
     </TabNav>
-  </div>)))
-  .add('centered tabs', withInfo()(() => (<div>
+  )))
+  .add('Centered tabs', withInfo()(() => (
     <TabNav activeTab="first" style={ ['small', 'center'] }>
       <TabNav.Tab onClick={ action('first tab clicked') } tabId="first">
         Tab #1
@@ -55,8 +116,8 @@ stories
         Tab #3
       </TabNav.Tab>
     </TabNav>
-  </div>)))
-  .add('plain tabs', withInfo()(() => (<div>
+  )))
+  .add('Plain tabs', withInfo()(() => (
     <TabNav activeTab="first" style={ ['small', 'sub'] }>
       <TabNav.Tab onClick={ action('first tab clicked') } tabId="first">
         Tab #1
@@ -68,5 +129,17 @@ stories
         Tab #3
       </TabNav.Tab>
     </TabNav>
-  </div>)));
-
+  )))
+  .add('Header tabs', withInfo()(() => (
+    <TabNav activeTab="first" style={ ['header'] }>
+      <TabNav.Tab onClick={ action('first tab clicked') } tabId="first">
+        Tab #1
+      </TabNav.Tab>
+      <TabNav.Tab onClick={ action('second tab clicked') } tabId="second">
+        Tab #2
+      </TabNav.Tab>
+      <TabNav.Tab onClick={ action('third tab clicked') } tabId="third">
+        Tab #3
+      </TabNav.Tab>
+    </TabNav>
+  )));

--- a/src/components/TabNav/index.js
+++ b/src/components/TabNav/index.js
@@ -58,6 +58,7 @@ TabNav.propTypes = {
   /** Various styles that can be given to the navigation */
   style: PropTypes.arrayOf(PropTypes.oneOf([
     'center',
+    'dashboard',
     'header',
     'left-pad',
     'plain',

--- a/src/components/TabNav/index.scss
+++ b/src/components/TabNav/index.scss
@@ -195,3 +195,32 @@
     }
   }
 }
+
+.oui-tabs--dashboard {
+  margin-left: -(spacer(4));
+  margin-right: -(spacer(4));
+
+  &--half {
+    margin-left: -(spacer(2));
+    margin-right: -(spacer(2));
+  }
+
+  .#{$namespace}tabs-nav__item,
+  .oui-tabs-nav__item {
+    padding-top: 0;
+    border: none;
+    background: none;
+
+    &.is-active {
+      color: #555;
+
+      &:after {
+        background: #0081BA;
+      }
+    }
+
+    &:first-child {
+      margin-left: spacer(2.5);
+    }
+  }
+}

--- a/src/components/TabNav/index.scss
+++ b/src/components/TabNav/index.scss
@@ -1,58 +1,5 @@
 ////
 /// Tabs
-/// @description Creates a set of tabs.
-/// @example[html] Default sized tabs
-///   <div class="#{$namespace}tabs" data-oui-tabs>
-///     <ul class="#{$namespace}tabs-nav">
-///       <li class="#{$namespace}tabs-nav__item is-active" data-oui-tabs-nav-item>Tab One</li>
-///       <li class="#{$namespace}tabs-nav__item" data-oui-tabs-nav-item>Tab Two</li>
-///       <li class="#{$namespace}tabs-nav__item" data-oui-tabs-nav-item>Tab Three</li>
-///     </ul>
-///     <div class="#{$namespace}tabs-pane" data-oui-tabs-pane>
-///       <div class="#{$namespace}tabs-pane__item is-active" data-oui-tabs-panes-item>Tab Content One</div>
-///       <div class="#{$namespace}tabs-pane__item" data-oui-tabs-panes-item>Tab Content Two</div>
-///       <div class="#{$namespace}tabs-pane__item" data-oui-tabs-panes-item>Tab Content Three</div>
-///     </div>
-///   </div>
-/// @example[html] Small tabs
-///   <div class="#{$namespace}tabs #{$namespace}tabs--small" data-oui-tabs>
-///     <ul class="#{$namespace}tabs-nav">
-///       <li class="#{$namespace}tabs-nav__item is-active" data-oui-tabs-nav-item>Tab One</li>
-///       <li class="#{$namespace}tabs-nav__item" data-oui-tabs-nav-item>Tab Two</li>
-///       <li class="#{$namespace}tabs-nav__item" data-oui-tabs-nav-item>Tab Three</li>
-///     </ul>
-///     <div class="#{$namespace}tabs-pane" data-oui-tabs-pane>
-///       <div class="#{$namespace}tabs-pane__item is-active" data-oui-tabs-panes-item>Tab Content One</div>
-///       <div class="#{$namespace}tabs-pane__item" data-oui-tabs-panes-item>Tab Content Two</div>
-///       <div class="#{$namespace}tabs-pane__item" data-oui-tabs-panes-item>Tab Content Three</div>
-///     </div>
-///   </div>
-/// @example[html] Center aligned small tabs
-///   <div class="#{$namespace}tabs #{$namespace}tabs--small #{$namespace}tabs--center" data-oui-tabs>
-///     <ul class="#{$namespace}tabs-nav">
-///       <li class="#{$namespace}tabs-nav__item is-active" data-oui-tabs-nav-item>Tab One</li>
-///       <li class="#{$namespace}tabs-nav__item" data-oui-tabs-nav-item>Tab Two</li>
-///       <li class="#{$namespace}tabs-nav__item" data-oui-tabs-nav-item>Tab Three</li>
-///     </ul>
-///     <div class="#{$namespace}tabs-pane" data-oui-tabs-pane>
-///       <div class="#{$namespace}tabs-pane__item is-active" data-oui-tabs-panes-item>Tab Content One</div>
-///       <div class="#{$namespace}tabs-pane__item" data-oui-tabs-panes-item>Tab Content Two</div>
-///       <div class="#{$namespace}tabs-pane__item" data-oui-tabs-panes-item>Tab Content Three</div>
-///     </div>
-///   </div>
-/// @example[html] Alternate small tab style with bottom border
-///   <div class="#{$namespace}tabs #{$namespace}tabs--small #{$namespace}tabs--sub" data-oui-tabs>
-///     <ul class="#{$namespace}tabs-nav">
-///       <li class="#{$namespace}tabs-nav__item is-active" data-oui-tabs-nav-item>Tab One</li>
-///       <li class="#{$namespace}tabs-nav__item" data-oui-tabs-nav-item>Tab Two</li>
-///       <li class="#{$namespace}tabs-nav__item" data-oui-tabs-nav-item>Tab Three</li>
-///     </ul>
-///     <div class="#{$namespace}tabs-pane" data-oui-tabs-pane>
-///       <div class="#{$namespace}tabs-pane__item is-active" data-oui-tabs-panes-item>Tab Content One</div>
-///       <div class="#{$namespace}tabs-pane__item" data-oui-tabs-panes-item>Tab Content Two</div>
-///       <div class="#{$namespace}tabs-pane__item" data-oui-tabs-panes-item>Tab Content Three</div>
-///     </div>
-///   </div>
 ////
 
 .#{$namespace}tabs-nav,


### PR DESCRIPTION
<img width="695" alt="screen shot 2018-07-11 at 8 19 06 pm" src="https://user-images.githubusercontent.com/16581943/42610736-ba041c78-8547-11e8-9903-d175ddb5a0ea.png">

This should be a drop-in replacement component for the TabNav in Optimizely X we use across the top of all dashboard pages, simply replace `<div class="lego-tabs dashboard-tabs">` with `<TabNav style={['dashboard']}>` and whatever children are needed:

```
<TabNav activeTab="second" style={ ['dashboard'] }>
  <TabNav.Tab onClick={ null } tabId="first">
    Tab #1
  </TabNav.Tab>
  <TabNav.Tab onClick={ null } tabId="second">
    Tab #2
  </TabNav.Tab>
  <TabNav.Tab onClick={ null } tabId="third">
    Tab #3
  </TabNav.Tab>
</TabNav>
```