### PR TITLE
Set AccordionSection content to take up the max height

### DIFF
--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -65,7 +65,7 @@ export function AccordionSection({
       <a className="accordion__link" onClick={ _onClickHandler }>{title}</a>
 
       <div className="accordion__content-wrap accordion__content-wrap__react">
-        <div className="accordion__content flex--dead-center flex--column">
+        <div className="accordion__content flex--column height--1-1">
           {children}
         </div>
       </div>


### PR DESCRIPTION
The content should default to taking up the maximum space. The internals layout of the accordion section was also dictating too much of the layout of the internal component by specifying that content should be centered. This makes it more flexible for the consumer.