### PR TITLE
Add mousedown handler to Button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Add mousedown handler to Button component
 
 ## 31.12.2 - 2018-08-23
 ### Changed

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -15,6 +15,7 @@ const Button = ({
   isDisabled = false,
   onBlur,
   onClick,
+  onMouseDown,
   size,
   style,
   testSection,
@@ -38,6 +39,7 @@ const Button = ({
       type={ type }
       onBlur={ onBlur }
       onClick={ onClick }
+      onMouseDown={ onMouseDown }
       data-test-section={ testSection }
       aria-label={ ariaLabel }>
       { children }
@@ -60,6 +62,8 @@ Button.propTypes = {
   onBlur: PropTypes.func,
   /** Function that fires when the button is clicked on */
   onClick: PropTypes.func,
+  /** Function that fires when the button is mouse downed */
+  onMouseDown: PropTypes.func,
   /** Various height and width options */
   size: PropTypes.oneOf([
     'tiny',
@@ -92,6 +96,7 @@ Button.propTypes = {
 Button.defaultProps = {
   onBlur: () => {},
   onClick: () => {},
+  onMouseDown: () => {},
 };
 
 Button.displayName = 'Button';

--- a/src/components/Button/tests/index.js
+++ b/src/components/Button/tests/index.js
@@ -37,6 +37,18 @@ describe('components/Button', () => {
     expect(onBlurSpy).toHaveBeenCalled();
   });
 
+  it('should call function that is passed in as `onMouseDown` after mousedown', () => {
+    const onMouseDownSpy = jest.fn();
+
+    const component = shallow(
+      <Button onMouseDown={ onMouseDownSpy }>Hello!</Button>
+    );
+
+    component.simulate('mousedown');
+
+    expect(onMouseDownSpy).toHaveBeenCalled();
+  });
+
   it('should add an `aria-label` when provided', () => {
     const component = shallow(
       <Button ariaLabel="a11y">Hello!</Button>

--- a/src/components/CopyButton/tests/__snapshots__/index.js.snap
+++ b/src/components/CopyButton/tests/__snapshots__/index.js.snap
@@ -8,6 +8,7 @@ exports[`components/CopyButton should render children the icon button 1`] = `
     ariaLabel="Copy code snippet"
     onBlur={[Function]}
     onClick={[Function]}
+    onMouseDown={[Function]}
     style="plain"
     testSection="fake-test-section-copy-button"
   >

--- a/src/components/EmptyDashboard/tests/__snapshots__/index.js.snap
+++ b/src/components/EmptyDashboard/tests/__snapshots__/index.js.snap
@@ -6,6 +6,7 @@ exports[`components/EmptyDashboard should render 1`] = `
     <Button
       onBlur={[Function]}
       onClick={[Function]}
+      onMouseDown={[Function]}
       style="highlight"
     >
       Highlight Button
@@ -100,6 +101,7 @@ exports[`components/EmptyDashboard should render 1`] = `
           <Button
             onBlur={[Function]}
             onClick={[Function]}
+            onMouseDown={[Function]}
             style="highlight"
           >
             <button
@@ -108,6 +110,7 @@ exports[`components/EmptyDashboard should render 1`] = `
               disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
+              onMouseDown={[Function]}
               type="button"
             >
               Highlight Button


### PR DESCRIPTION
**Summary**

I ran into some issues with blur events being executed before clicks. The issue is caused by the browser's event object hierarchy.

I'd like to attach a mouse-down handler to the Button component, so that blur event handlers are executed after click handlers.

reference: https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Overview_of_Events_and_Handlers

example of the event hierarchy in action: https://codepen.io/mudassir0909/pen/eIHqB