### PR TITLE
Adding a new badge type for bad-news.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 ## Unreleased
 - [Patch] Add mousedown handler to Button component
 - [Patch] Add support for activatorLabel property in SelectDropdown item objects
+- [Patch] Add a new badge type for bad-news
 
 ## 31.12.3 - 2018-08-24
 ### Changed

--- a/src/components/Badge/Badge.story.js
+++ b/src/components/Badge/Badge.story.js
@@ -22,6 +22,7 @@ stories
     <Badge color="live">Live</Badge>
     <Badge color="primary">Primary</Badge>
     <Badge color="plain">Plain</Badge>
+    <Badge color="bad-news">Bad News</Badge>,
   </div>))
   .add('with text', withInfo()(() => (<div className="flex flex-align--center">
     <Badge color="draft">1</Badge>{ text('text', 'Unpublished Change') }

--- a/src/components/Badge/example/index.js
+++ b/src/components/Badge/example/index.js
@@ -10,6 +10,7 @@ export default [
       <Badge color="live">Live</Badge>,
       <Badge color="primary">Primary</Badge>,
       <Badge color="plain">Plain</Badge>,
+      <Badge color="bad-news">Bad News</Badge>,
     ],
   },
   {

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -27,7 +27,7 @@ Badge.propTypes = {
   /** Text that appears within the component */
   children: PropTypes.node.isRequired,
   /** Various color schemes */
-  color: PropTypes.oneOf(['default', 'draft', 'live', 'primary', 'plain']),
+  color: PropTypes.oneOf(['default', 'draft', 'live', 'primary', 'plain', 'bad-news']),
   /** Hook for automated JavaScript tests */
   testSection: PropTypes.string,
 };

--- a/src/components/Badge/index.scss
+++ b/src/components/Badge/index.scss
@@ -67,3 +67,8 @@
   background: transparent;
   color: map-fetch($color, ui, medium);
 }
+
+.#{$namespace}badge > li.badge__bad-news,
+.oui-badge--bad-news {
+  background: map-fetch($color, ui, bad-news);
+}


### PR DESCRIPTION
**Summary:**
For bad news a red colored badge was missing, So I just added it.
![image](https://user-images.githubusercontent.com/3541275/45079987-44194c80-b10d-11e8-9837-565eb07d5c2a.png)
