### PR TITLE
Fix disclose table styling post rebrand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Minor change to background colors for DiscloseTable 
 
 ## 40.1.0 - 2018-09-19
 - [Feature] Add Steps component

--- a/src/components/DiscloseTable/index.scss
+++ b/src/components/DiscloseTable/index.scss
@@ -33,14 +33,14 @@
       border-right: 1px solid transparent;
 
       &:hover {
-        background-color: map-fetch($color, background, brand-light);
         cursor: pointer;
+        background-color: map-fetch($brand-color, light-blue-6);
       }
 
       &.is-active {
         @extend %border--sides;
         @extend %border--top;
-        background-color: map-fetch($color, background, faint);
+        background-color: map-fetch($root-color, grey-03);
       }
     }
 


### PR DESCRIPTION
**Summary**
The styling for DiscloseTable needs to be tweaked post rebrand so that the hover and selected colors are correct.

After changes:
![image](https://user-images.githubusercontent.com/2287470/45849998-51842880-bd02-11e8-984c-b724cea486a2.png)
(Blue is hovered on, just no mouse visible)