### PR TITLE
Drau/colors refined

### DIFF
--- a/.storybook/overview.story.js
+++ b/.storybook/overview.story.js
@@ -72,6 +72,18 @@ stories
          <h6>H6 Experiments</h6>
       </div>
 
+      <div class="oui--swatches push--ends">
+         <span className="width--50 height--50 display--inline-block background--red"></span>
+         <span className="width--50 height--50 display--inline-block background--gold"></span>
+         <span className="width--50 height--50 display--inline-block background--indigo"></span>
+         <span className="width--50 height--50 display--inline-block background--cyan"></span>
+         <span className="width--50 height--50 display--inline-block background--green"></span>
+         <span className="width--50 height--50 display--inline-block background--blue"></span>
+         <span className="width--50 height--50 display--inline-block background--orange"></span>
+         <span className="width--50 height--50 display--inline-block background--white-40b"></span>
+
+      </div>
+
       <div className="push--ends">
         <Badge color="default">Default</Badge>
         <Badge color="draft">Draft</Badge>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- Updated color palette to reflect latest design team changes
+- Added SASS loop to auto-generate CSS3 --var colors from $brand-color base color set
 
 ## 40.1.0 - 2018-09-19
 - [Feature] Add Steps component

--- a/src/oui/_oui-variables.scss
+++ b/src/oui/_oui-variables.scss
@@ -11,50 +11,28 @@
 
 $namespace                   : '' !default;
 
+/// Spacing Unit
+/// @description Defines spacing for paddings and margins using `spacer`
+/// function.
+
+$spacer-unit                 : 10px;
+
 /// Colors
 /// @description Default color for objects' borders etc.
 
 /// Do not use these values directly in your Sass files. Use the more
 /// specifically named variables below that use these root values.
 
-$base-black                  : #000;
-$base-white                  : #FFF;
-
-// CSS3 Variables
+$base-black                  : #000000;
+$base-white                  : #FFFFFF;
 
 :root {
-  /* brand */
-  --light-blue-100           : #0037FF;
-  --light-blue-75            : #4069FF;
-  --light-blue-50            : #809BFF;
-  --light-blue-25            : #BFCDFF;
-  --light-blue-10            : #EAEDFA;
-  --light-blue-6             : #F3F6FF;
-  --dark-blue-75             : #46456A;
-
-  /* indicators */
-  --yellow                   : #FFCE00;
-  --red                      : #E93D28;
-  --green                    : #00A878;
-  --purple                   : #7500FF;
-  --cyan                     : #36D4FF;
-
-  /* greys */
-  --dark-blue-100            : #080738;
-  --dark-blue-50             : #83839B;
-  --dark-blue-25             : #C1C1CD;
-  --grey-50                  : #E8E8E8;
-  --grey-25                  : #F9F9F9;
-  --white                    : #FFFFFF;
-
-   /* ui */
    --wide-shadow             : 0 1px 3px rgba(0,0,0,0.10), 0 1px 2px rgba(0,0,0,0.17);
    --border-radius           : 8px;
    --highlight               : var(--light-blue-6);
    --ron-project-badge       : #7b81d1;
 }
 
-// Duplicate CSS3 vars available in SASS
 $brand-color: (
 
   /* brand */
@@ -67,11 +45,13 @@ $brand-color: (
   dark-blue-75               : #46456A,
 
   /* indicators */
-  yellow                     : #FFCE00,
-  red                        : #E93D28,
-  green                      : #00A878,
-  purple                     : #7500FF,
-  cyan                       : #36D4FF,
+  gold                       : #FFD233,
+  red                        : #FF5B5B,
+  green                      : #33CF76,
+  indigo                     : #8354FF,
+  cyan                       : #33D4FF,
+  blue                       : #33A5FF,
+  orange                     : #FF9C33,
 
   /* greys */
   dark-blue-100              : #080738,
@@ -80,18 +60,37 @@ $brand-color: (
   grey-50                    : #E8E8E8,
   grey-25                    : #F9F9F9,
   paper                      : #FDFDFD,
-
-  /* data-visualization */
-  data-rich-1                : #000041,
-  data-rich-2                : #0000CB,
-  data-rich-3                : #0081FF, // primary token
-  data-rich-4                : #02DA81, // live
-  data-rich-5                : #7EF41E,
-  data-rich-6                : #FDEE02,
-  data-rich-7                : #FFAB00, // draft
-  data-rich-8                : #FF3300
+  white-40b                  : shade($base-white, 40%),
 
 );
+
+
+
+// CSS3 Variables
+// Create CSS3 variables for each $brand-color
+// Use `color: var(--light-blue-100);`
+:root {
+  @each $name, $hex in map-fetch($brand-color) {
+    --#{$name}: #{$hex};
+  }
+}
+
+// Background colors
+// Use `.background--colorname`
+@each $name, $hex in map-fetch($brand-color) {
+  .background--#{$name} {
+    background-color: #{$hex};
+    color: white;
+  }
+}
+
+// Foreground colors
+// Use `.color--colorname`
+@each $name, $hex in map-fetch($brand-color) {
+  .color--#{$name} {
+    color: #{$hex};
+  }
+}
 
 $root-color: (
   grey-85                    : tint($base-black, 15%),
@@ -106,12 +105,12 @@ $root-color: (
   brand                      : map-fetch($brand-color, light-blue-75),
   brand-light                : map-fetch($brand-color, light-blue-25),
   brand-dark                 : map-fetch($brand-color, dark-blue-75),
-  warning                    : map-fetch($brand-color, yellow),
+  warning                    : map-fetch($brand-color, gold),
   bad-news                   : map-fetch($brand-color, red),
   good-news                  : map-fetch($brand-color, green),
-  draft                      : map-fetch($brand-color, data-rich-7),
-  live                       : map-fetch($brand-color, data-rich-4),
-  admin                      : map-fetch($brand-color, purple),
+  draft                      : map-fetch($brand-color, orange),
+  live                       : map-fetch($brand-color, green),
+  admin                      : map-fetch($brand-color, indigo),
   highlight                  : map-fetch($brand-color, light-blue-6)
 );
 
@@ -306,21 +305,6 @@ $button: (
         color                : map-fetch($brand-color, dark-blue-100),
       )
     ),
-    // outline-reverse: (
-    //   background             : transparent,
-    //   border                 : $base-white,
-    //   color                  : $base-white,
-    //   hover:(
-    //     background           : transparent,
-    //     border               : #E0E1E5,
-    //     color                : #E5E5E9,
-    //   ),
-    //   active:(
-    //     background           : transparent,
-    //     border               : $base-white,
-    //     color                : $base-white,
-    //   )
-    // ),
     danger: (
       background             : map-fetch($brand-color, red),
       border                 : map-fetch($brand-color, red),
@@ -356,8 +340,8 @@ $button: (
       )
     ),
     disabled: (
-      background             : #EFF0F2,
-      border                 : #E5E5E9,
+      background             : map-fetch($brand-color, grey-25),
+      border                 : shade(map-fetch($brand-color, grey-50), 10%),
       color                  : map-fetch($color, text, muted)
     )
   )
@@ -368,8 +352,8 @@ $button: (
 
 $token: (
   background-color: (
-    primary                  : map-fetch($brand-color, data-rich-3),
-    secondary                : map-fetch($brand-color, dark-blue-50)
+    primary                  : map-fetch($brand-color, blue),
+    secondary                : map-fetch($brand-color, white-40b)
   ),
   token__number: (
     min-width                : 10px
@@ -404,7 +388,7 @@ $rangeslider: (
 /// Badge
 
 $badge: (
-  background-color           : map-fetch($brand-color, dark-blue-50),
+  background-color           : map-fetch($brand-color, white-40b),
   size                       : 17px,
   min-width                  : 28px, // Graphik letter m width approx.
   font-size                  : 10px,
@@ -567,9 +551,3 @@ $spinner: (
 $z-index: (
   poptip                     : 100
 );
-
-/// Spacing Unit
-/// @description Defines spacing for paddings and margins using `spacer`
-/// function.
-
-$spacer-unit                 : 10px;

--- a/src/oui/_oui-variables.scss
+++ b/src/oui/_oui-variables.scss
@@ -31,6 +31,7 @@ $base-white                  : #FFFFFF;
    --border-radius           : 8px;
    --highlight               : var(--light-blue-6);
    --ron-project-badge       : #7b81d1;
+   --white                   : #FFFFFF;
 }
 
 $brand-color: (


### PR DESCRIPTION
1. This updates our SASS and CSS3 color variables with a the latest palette from Shane and d-team (includes badge colors)

![screen shot 2018-09-20 at 4 04 30 pm](https://user-images.githubusercontent.com/16581943/45851275-e41acc80-bcee-11e8-9759-8611bbee77b7.png)

![colors-9-19-18](https://user-images.githubusercontent.com/16581943/45851255-d49b8380-bcee-11e8-8c67-24d6b269403b.png)

2. I've simplified the color set so the SASS color definitions also auto generate the css3 variables so we don't have to create two sets of hex color sets manually.