### PR TITLE
Drau/listgroup padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Add density prop for ListGroup.Item
 
 ## 40.12.2 - 2018-11-08
 - [Patch] Travis CI change for auto-publish css

--- a/src/components/ListGroup/ListGroup.story.js
+++ b/src/components/ListGroup/ListGroup.story.js
@@ -41,11 +41,12 @@ stories
   .add('Default', withInfo(infoAddonConfig)(() => {
 
     const theTitle = text('The Main Title', 'Hello World!');
+    const itemDensity = select('item.density', { 'loose': 'loose', 'tight': 'tight' }, 'loose');
     const theSubtitle = text('The Subtitle', 'What if it runs really long and could break into several lines...');
     const demoArray = object('demoArray (example knob, not a prop)', [
       { name: 'ListGroup.Item Text 1', value: 'Value 1' },
       { name: 'ListGroup.Item Text 2', value: 'Value 2' },
-      { name: 'ListGroup.Item Text 3', value: 'Value 3', density: 'tight' },
+      { name: 'ListGroup.Item Text 3 (note: <ListGroup.item density=tight>)', value: 'Value 3', density: 'tight' },
       { name: 'ListGroup.Item Text 4', value: 'Value 4' },
       { name: 'ListGroup.Item Text 5', value: 'Value 5' },
       { name: 'ListGroup.Item Text 6', value: 'Value 6' },
@@ -56,7 +57,7 @@ stories
         title={ theTitle }
         subtitle={ theSubtitle }>
         { demoArray.map(item => (
-          <ListGroup.Item key={ item.value } density={ item.density }>
+          <ListGroup.Item key={ item.value } density={ item.density || itemDensity }>
             { item.name }<br/>
             <span className="muted">{ item.value }</span>
           </ListGroup.Item>

--- a/src/components/ListGroup/ListGroup.story.js
+++ b/src/components/ListGroup/ListGroup.story.js
@@ -38,14 +38,14 @@ stories
   ));
 
 stories
-  .add('ListGroup default', withInfo(infoAddonConfig)(() => {
+  .add('Default', withInfo(infoAddonConfig)(() => {
 
     const theTitle = text('The Main Title', 'Hello World!');
     const theSubtitle = text('The Subtitle', 'What if it runs really long and could break into several lines...');
     const demoArray = object('demoArray (example knob, not a prop)', [
       { name: 'ListGroup.Item Text 1', value: 'Value 1' },
       { name: 'ListGroup.Item Text 2', value: 'Value 2' },
-      { name: 'ListGroup.Item Text 3', value: 'Value 3' },
+      { name: 'ListGroup.Item Text 3', value: 'Value 3', density: 'tight' },
       { name: 'ListGroup.Item Text 4', value: 'Value 4' },
       { name: 'ListGroup.Item Text 5', value: 'Value 5' },
       { name: 'ListGroup.Item Text 6', value: 'Value 6' },
@@ -56,7 +56,7 @@ stories
         title={ theTitle }
         subtitle={ theSubtitle }>
         { demoArray.map(item => (
-          <ListGroup.Item key={ item.value }>
+          <ListGroup.Item key={ item.value } density={ item.density }>
             { item.name }<br/>
             <span className="muted">{ item.value }</span>
           </ListGroup.Item>
@@ -64,7 +64,7 @@ stories
       </ListGroup>
     );
   }))
-  .add('ListGroup spacing example', withInfo()(() => {
+  .add('ListGroup density tight', withInfo()(() => {
     return (
       <ListGroup
         title='ListGroup Title'
@@ -78,9 +78,10 @@ stories
         <ListGroup.Item>
           <Input placeholder="Plain Input inside <ListGroup>" />
         </ListGroup.Item>
-        <ListGroup.Item density={ select('Density (4th item)', {
-          'loose': 'loose',
-          'tight': 'tight'}, 'tight') }>
+        <ListGroup.Item
+          density={ select('Density (4th item)', {
+            'loose': 'loose',
+            'tight': 'tight'}, 'tight') }>
           <Input placeholder="Plain Input inside <ListGroup density=tight> (try the density knob!)" />
         </ListGroup.Item>
         <ListGroup.Item>

--- a/src/components/ListGroup/ListGroup.story.js
+++ b/src/components/ListGroup/ListGroup.story.js
@@ -1,10 +1,11 @@
 import React from 'react';
 
 import { storiesOf } from '@storybook/react';
-import { withKnobs, object, text } from '@storybook/addon-knobs';
+import { withKnobs, select, object, text } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import ListGroup from '../ListGroup';
+import Input from '../Input';
 
 /**
  * This is a clone of the contents of README.md,
@@ -56,10 +57,38 @@ stories
         subtitle={ theSubtitle }>
         { demoArray.map(item => (
           <ListGroup.Item key={ item.value }>
-            { item.name }
-            <p className="muted">{ item.value }</p>
+            { item.name }<br/>
+            <span className="muted">{ item.value }</span>
           </ListGroup.Item>
         )) }
+      </ListGroup>
+    );
+  }))
+  .add('ListGroup spacing example', withInfo()(() => {
+    return (
+      <ListGroup
+        title='ListGroup Title'
+        subtitle='ListGroup Subtitle'>
+        <ListGroup.Item>
+          <Input placeholder="Plain Input inside <ListGroup>" />
+        </ListGroup.Item>
+        <ListGroup.Item>
+          <Input placeholder="Plain Input inside <ListGroup>" />
+        </ListGroup.Item>
+        <ListGroup.Item>
+          <Input placeholder="Plain Input inside <ListGroup>" />
+        </ListGroup.Item>
+        <ListGroup.Item density={ select('Density (4th item)', {
+          'loose': 'loose',
+          'tight': 'tight'}, 'tight') }>
+          <Input placeholder="Plain Input inside <ListGroup density=tight> (try the density knob!)" />
+        </ListGroup.Item>
+        <ListGroup.Item>
+          <Input placeholder="Plain Input inside <ListGroup>" />
+        </ListGroup.Item>
+        <ListGroup.Item>
+          <Input placeholder="Plain Input inside <ListGroup>" />
+        </ListGroup.Item>
       </ListGroup>
     );
   }));

--- a/src/components/ListGroup/ListGroup.story.js
+++ b/src/components/ListGroup/ListGroup.story.js
@@ -46,7 +46,7 @@ stories
     const demoArray = object('demoArray (example knob, not a prop)', [
       { name: 'ListGroup.Item Text 1', value: 'Value 1' },
       { name: 'ListGroup.Item Text 2', value: 'Value 2' },
-      { name: 'ListGroup.Item Text 3 (note: <ListGroup.item density=tight>)', value: 'Value 3', density: 'tight' },
+      { name: 'ListGroup.Item Text 3 (density=tight)', value: 'Value 3', density: 'tight' },
       { name: 'ListGroup.Item Text 4', value: 'Value 4' },
       { name: 'ListGroup.Item Text 5', value: 'Value 5' },
       { name: 'ListGroup.Item Text 6', value: 'Value 6' },

--- a/src/components/ListGroup/index.js
+++ b/src/components/ListGroup/index.js
@@ -39,13 +39,14 @@ ListGroup.defaultProps = {
 export const ListGroupItem = ({
   children,
   testSection,
-  density='loose',
+  density = 'loose',
 }) => {
+
   let classes = classNames({
     'listgroup__item': true,
     'border--bottom': true,
-    'soft--bottom soft--top': density=='tight',
-    'soft-double--bottom soft-double--top': density=='loose',
+    'soft--bottom soft--top': density === 'tight',
+    'soft-double--bottom soft-double--top': density === 'loose',
   });
 
   return (

--- a/src/components/ListGroup/index.js
+++ b/src/components/ListGroup/index.js
@@ -39,7 +39,7 @@ ListGroup.defaultProps = {
 export const ListGroupItem = ({
   children,
   testSection,
-  density = 'loose',
+  density,
 }) => {
 
   let classes = classNames({
@@ -59,6 +59,10 @@ ListGroupItem.propTypes = {
   children: PropTypes.node.isRequired,
   density: PropTypes.oneOf(['tight', 'loose']),
   testSection: PropTypes.string,
+};
+
+ListGroupItem.defaultProps = {
+  density: 'loose',
 };
 
 ListGroup.Item = ListGroupItem;

--- a/src/components/ListGroup/index.js
+++ b/src/components/ListGroup/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 export const ListGroup = ({
   children,
@@ -38,16 +39,25 @@ ListGroup.defaultProps = {
 export const ListGroupItem = ({
   children,
   testSection,
+  density='loose',
 }) => {
+  let classes = classNames({
+    'listgroup__item': true,
+    'border--bottom': true,
+    'soft--bottom soft--top': density=='tight',
+    'soft-double--bottom soft-double--top': density=='loose',
+  });
+
   return (
-    <div className="listgroup__item push--bottom border--bottom" data-test-section={ testSection }>
+    <div className={ classes } data-test-section={ testSection }>
       { children }
     </div>
   );
 };
 ListGroupItem.propTypes = {
   children: PropTypes.node.isRequired,
-  testSection: '',
+  density: PropTypes.oneOf(['tight', 'loose']),
+  testSection: PropTypes.string,
 };
 
 ListGroup.Item = ListGroupItem;

--- a/src/components/ListGroup/index.scss
+++ b/src/components/ListGroup/index.scss
@@ -6,7 +6,12 @@
 .oui-listgroup,
 .listgroup {
 
-  .listgroup__item:last-of-type {
+  .listgroup__item:first-child {
+    padding-top: 0 !important;
+  }
+  .listgroup__item:last-child {
     border: 0 !important;
   }
+
+
 }

--- a/src/components/ListGroup/tests/__snapshots__/index.js.snap
+++ b/src/components/ListGroup/tests/__snapshots__/index.js.snap
@@ -25,10 +25,14 @@ exports[`components/ListGroup render listgroup with correct classes 1`] = `
   <div
     className="group flex--1 soft--left"
   >
-    <ListGroupItem>
+    <ListGroupItem
+      density="loose"
+    >
       Item!
     </ListGroupItem>
-    <ListGroupItem>
+    <ListGroupItem
+      density="loose"
+    >
       Item 2!
     </ListGroupItem>
   </div>


### PR DESCRIPTION
### Summary
This is a fix for @fayyazarshad and will add default padding to the inner `<ListGroup.Item>`s and give you the option to override individual list group items like so: `<ListGroup.Item density="tight">`

### With text
<img width="751" alt="screen shot 2018-11-09 at 5 06 09 pm" src="https://user-images.githubusercontent.com/16581943/48295557-cc83d880-e441-11e8-93df-a845ad99e79b.png">

### With plain `<Input>s`
<img width="749" alt="screen shot 2018-11-09 at 5 06 15 pm" src="https://user-images.githubusercontent.com/16581943/48295560-d279b980-e441-11e8-858b-bb898e85336d.png">
