### PR TITLE
Add ConfirmButton component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Feature] Add ConfirmButton component
 
 ## 40.13.2 - 2018-11-16
 - [Patch] FilterPicker patches, all backwards compatible (#1090)

--- a/src/components/ConfirmButton/ConfirmButton.js
+++ b/src/components/ConfirmButton/ConfirmButton.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { noop } from 'lodash';
+
+import Button from '../Button';
+import ButtonRow from '../ButtonRow';
+
+/**
+ * ConfirmButton
+ * This component render a cancel/confirm button group
+ */
+
+const ConfirmButton = (props) => {
+  const {
+    cancelStyle,
+    cancelText,
+    confirmStyle,
+    confirmText,
+    disableCancel,
+    disableConfirm,
+    isSubmit,
+    onCancel,
+    onConfirm,
+  } = props;
+
+  return (
+    <ButtonRow
+      rightGroup={ [
+        <Button
+          key='1'
+          onMouseDown={ onCancel }
+          testSection='confirm-button-cancel-button'
+          isDisabled={ disableCancel }
+          style={ cancelStyle }>
+          { cancelText }
+        </Button>,
+        <Button
+          key='2'
+          onMouseDown={ onConfirm }
+          isDisabled={ disableConfirm }
+          isSubmit={ isSubmit }
+          testSection='confirm-button-confirm-button'
+          style={ confirmStyle }>
+          { confirmText }
+        </Button>,
+      ] }
+    />
+  );
+};
+
+ConfirmButton.defaultProps = {
+  disableCancel: false,
+  disableConfirm: false,
+  cancelStyle: 'plain',
+  confirmStyle: 'highlight',
+  cancelText: 'Cancel',
+  confirmText: 'Save',
+  isSubmit: true,
+  onCancel: noop,
+  onConfirm: noop,
+};
+
+ConfirmButton.propTypes = {
+  /** Sets style of cancel button */
+  cancelStyle: PropTypes.oneOf([
+    'highlight',
+    'danger',
+    'danger-outline',
+    'outline',
+    'outline-reverse',
+    'plain',
+    'toggle',
+    'underline',
+    'unstyled',
+  ]),
+  /** Cancel button text */
+  cancelText: PropTypes.string,
+  /** Sets style of confirm button */
+  confirmStyle: PropTypes.oneOf([
+    'highlight',
+    'danger',
+    'danger-outline',
+    'outline',
+    'outline-reverse',
+    'plain',
+    'toggle',
+    'underline',
+    'unstyled',
+  ]),
+  /** Confirm button text */
+  confirmText: PropTypes.string,
+  /** Determines if the cancel button is disabled */
+  disableCancel: PropTypes.bool,
+  /** Determines if the confirm button is disabled */
+  disableConfirm: PropTypes.bool,
+  /** Determines if confirm button is a submit button */
+  isSubmit: PropTypes.bool,
+  /** Function that is called when cancel button is clicked */
+  onCancel: PropTypes.func,
+  /** Function that is called when confirm button is clicked */
+  onConfirm: PropTypes.func,
+};
+
+export default ConfirmButton;

--- a/src/components/ConfirmButton/ConfirmButton.story.js
+++ b/src/components/ConfirmButton/ConfirmButton.story.js
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import ConfirmButton from './index.js';
+
+const styleOptions = {
+  highlight: 'highlight',
+  danger: 'danger',
+  'danger-outline': 'danger-outline',
+  outline: 'outline',
+  'outline-reverse': 'outline-reverse',
+  plain: 'plain',
+  toggle: 'toggle',
+  underline: 'underline',
+  unstyled: 'unstyled',
+};
+
+const stories = storiesOf('ConfirmButton', module);
+stories
+  .addDecorator(withKnobs)
+  .addDecorator(story => (
+    <div id="root-preview">
+      {story()}
+    </div>
+  ));
+
+stories
+  .add('default', withInfo()(() => {
+    return (
+      <ConfirmButton
+        disableCancel={ boolean('disableCancel', false) }
+        disableConfirm={ boolean('disableConfirm', false) }
+        cancelStyle={ select('cancelStyle', styleOptions, 'plain') }
+        cancelText={ text('cancelText', 'Cancel') }
+        confirmStyle={ select('confirmStyle', styleOptions, 'highlight') }
+        confirmText={ text('confirmText', 'Save') }
+        onCancel={ action('cancel') }
+        onConfirm={ action('confirm') }
+      />
+    );
+  }));
+

--- a/src/components/ConfirmButton/README.md
+++ b/src/components/ConfirmButton/README.md
@@ -1,0 +1,10 @@
+# ConfirmButton 
+
+Example:
+
+```js
+<ConfirmButton
+  onCancel={ handleCancelClick }
+  onConfirm={ handleConfirmClick }
+/>
+```

--- a/src/components/ConfirmButton/examples/index.js
+++ b/src/components/ConfirmButton/examples/index.js
@@ -1,0 +1,18 @@
+/* eslint-disable react/jsx-key */
+import React from 'react';
+import ConfirmButton from '../index';
+
+export default [
+  {
+    examples: [
+      <ConfirmButton
+        disableCancel={ false }
+        disableConfirm={ false }
+        cancelStyle='plain'
+        cancelText='Cancel'
+        confirmStyle='highlight'
+        confirmText='Save'
+      />,
+    ],
+  },
+];

--- a/src/components/ConfirmButton/index.js
+++ b/src/components/ConfirmButton/index.js
@@ -1,0 +1,3 @@
+import ConfirmButton from './ConfirmButton';
+
+export default ConfirmButton;

--- a/src/components/ConfirmButton/tests/index.js
+++ b/src/components/ConfirmButton/tests/index.js
@@ -1,0 +1,72 @@
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import ConfirmButton from '../index';
+
+describe('components/ConfirmButton', function() {
+  let component;
+  let onCancelSpy;
+  let onConfirmSpy;
+  beforeEach(function() {
+    onCancelSpy = jest.fn();
+    onConfirmSpy = jest.fn();
+    component = mount(
+      <ConfirmButton
+        onCancel={ onCancelSpy }
+        onConfirm={ onConfirmSpy }
+      />
+    );
+  });
+
+  afterEach(function() {
+    component.unmount();
+  });
+
+  describe('basic rendering', function() {
+    it('should render ButtonRow', function() {
+      const buttonRowComponent = component.find('ButtonRow');
+      expect(buttonRowComponent.exists()).toBe(true);
+      expect(buttonRowComponent.prop('rightGroup').length).toEqual(2);
+    });
+
+    it('should render cancel button', function() {
+      const cancelButton = component.find('[data-test-section="confirm-button-cancel-button"]');
+      expect(cancelButton.exists()).toBe(true);
+    });
+
+    it('should render confirm button', function() {
+      const confirmButton = component.find('[data-test-section="confirm-button-cancel-button"]');
+      expect(confirmButton.exists()).toBe(true);
+    });
+  });
+
+  describe('editing', function() {
+    it('should call onCancel when cancel button is clicked', function() {
+      const cancelButton = component.find('[data-test-section="confirm-button-cancel-button"]');
+      cancelButton.simulate('mousedown');
+      expect(onCancelSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onCofirm when confirm button is clicked', function() {
+      const confirmButton = component.find('[data-test-section="confirm-button-confirm-button"]');
+      confirmButton.simulate('mousedown');
+      expect(onConfirmSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call onCancel when cancel button is disabled and clicked', function() {
+      component.setProps({ disableCancel: true });
+      const cancelButton = component.find('[data-test-section="confirm-button-cancel-button"]');
+      cancelButton.simulate('mousedown');
+      expect(onCancelSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not call onConfirm when confirm button is disabled and clicked', function() {
+      component.setProps({ disableConfirm: true });
+      const confirmButton = component.find('[data-test-section="confirm-button-confirm-button"]');
+      confirmButton.simulate('mousedown');
+      expect(onConfirmSpy).toHaveBeenCalledTimes(0);
+    });
+  });
+
+});


### PR DESCRIPTION
## Summary

This PR creates a `ConfirmButton` component that renders a cancel/confirm button group.

![screen shot 2018-11-19 at 9 38 48 am](https://user-images.githubusercontent.com/41028823/48720822-26c12e00-ebe6-11e8-9613-24a89bbedb64.png)

## Test Plan

1. Run the test suite `yarn test`
2. Verify it renders correctly in storybook `yarn storybook`
