### PR TITLE
patch(SelectDropdown): SelectDropdown gets disabled when the isDisabled prop is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 
 ## Unreleased
 
+### Fixed
+- [Patch] Fixed <SelectDropdown> Component. Gets properly disabled when isDisabled prop is true
+
 ## 40.14.0 - 2019-1-4
 - [Feature] Added <TokensInput> Component (#1097)
 

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -23,7 +23,7 @@ class Dropdown extends React.Component {
   };
 
   handleToggle = () => {
-    if(this.props.isDisabled) {
+    if (this.props.isDisabled) {
       return;
     }
     this.props.setOverChildren(false);

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -23,6 +23,9 @@ class Dropdown extends React.Component {
   };
 
   handleToggle = () => {
+    if(this.props.isDisabled) {
+      return;
+    }
     this.props.setOverChildren(false);
     this.props.toggle();
   };

--- a/src/components/SelectDropdown/SelectDropdown.story.js
+++ b/src/components/SelectDropdown/SelectDropdown.story.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { storiesOf } from '@storybook/react';
-import { withKnobs } from '@storybook/addon-knobs';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
 
@@ -80,6 +80,18 @@ stories.add('default', withInfo()(() => {
         value={ 'dog' }
         onChange={ action('SelectDropdown value changed') }
         minDropdownWidth={ '400px ' }
+      />
+    </Container>
+  );
+})).add('Disabled', withInfo()(() => {
+  return (
+    <Container>
+      <SelectDropdown
+        items={ items }
+        value={ 'dog' }
+        minDropdownWidth={ '400px ' }
+        isDisabled={ boolean('isDisabled', true) }
+        onChange={ action('SelectDropdown value changed') }
       />
     </Container>
   );

--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -107,7 +107,7 @@ class SelectDropdown extends React.Component {
   };
 
   render() {
-    const { buttonStyle, value, width, zIndex } = this.props;
+    const { buttonStyle, value, width, zIndex, isDisabled } = this.props;
     let selectedItem;
     this.props.items.forEach(item => {
       if (item.value === value) {
@@ -124,6 +124,7 @@ class SelectDropdown extends React.Component {
     return (
       <Dropdown
         { ...(zIndex ? { zIndex } : {}) }
+        isDisabled={ isDisabled }
         activator={ (
           <div
             style={{ width: width}}

--- a/src/components/SelectDropdown/tests/index.js
+++ b/src/components/SelectDropdown/tests/index.js
@@ -89,6 +89,20 @@ describe('components/SelectDropdown', function() {
     expect(component.find('DropdownContents').prop('minWidth')).toEqual('400px');
   });
 
+  it('should not render DropdownContents when isDisabled is true', function() {
+    component = mount(
+      <SelectDropdown
+        items={ items }
+        isDisabled={ true }
+        value={ 'value 2' }
+        onChange={ onChange }
+      />);
+    const activator = component.find('Button');
+    activator.simulate('click');
+    expect(component.find('Dropdown').prop('isDisabled')).toEqual(true);
+    expect(component.find('DropdownContents').length).toEqual(0);
+  });
+
   it('should display activatorLabel if provided', function() {
     const itemsWithActivatorLabel = [
       {


### PR DESCRIPTION
### The Following Files include changes for the fix
1. `src/components/Dropdown/index.js`
2. `src/components/SelectDropdown/index.js`

### The Following Storybook file includes changes
1. `src/components/SelectDropdown/SelectDropdown.story.js`

### Test case added in the following file for SelectDropdown isDisabled prop
1. `src/components/SelectDropdown/tests/index.js`

### Updated CHANGELOG 
