### PR TITLE
feat (<Disclose>): Add a noIndent prop to remove the indentation of the clickable toggle

### DIFF
--- a/src/components/Disclose/index.js
+++ b/src/components/Disclose/index.js
@@ -5,10 +5,11 @@ import { toClass } from 'recompose';
 import { withToggle } from '../../utils/recompose-utils';
 
 const Disclose = ({
-  isOpen,
   children,
-  headerStyle,
   childrenStyle,
+  headerStyle,
+  isOpen,
+  noIndent,
   title,
   toggle,
 }) => {
@@ -24,11 +25,17 @@ const Disclose = ({
     {
       ['background--faint display--block']: headerStyle === 'header',
       ['border--all background--faint display--block']: headerStyle === 'header-bordered',
+      ['hard--left']: noIndent,
     }
   );
-  const arrow = isOpen ? 'oui-disclose is-active' : 'oui-disclose';
+  const arrowClass = classNames(
+    'oui-disclose',
+    {
+      ['is-active']: isOpen,
+    },
+  );
   return (
-    <div className={ arrow } style={{marginTop: '-1px'}}>
+    <div className={ arrowClass } style={{marginTop: '-1px'}}>
       <a onClick={ toggle } className={ linkClass }>
         <div className='oui-disclose__arrow'>
           <span className="oui-disclose__symbol push-half--right"></span>
@@ -48,8 +55,13 @@ Disclose.propTypes = {
   headerStyle: PropTypes.string,
   isOpen: PropTypes.bool,
   noBorder: PropTypes.bool,
+  noIndent: PropTypes.bool,
   title: PropTypes.string.isRequired,
   toggle: PropTypes.func,
+};
+
+Disclose.defaultProps = {
+  noIndent: false,
 };
 
 export default withToggle(toClass(Disclose));

--- a/src/components/Disclose/tests/index.js
+++ b/src/components/Disclose/tests/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 
 import Disclose from '../index';
@@ -10,5 +10,10 @@ const disclose = shallow(<Disclose title='Some title'> <div>disclose this</div> 
 describe('Disclose Component ', () => {
   it('renders correctly', () => {
     expect(shallowToJson(disclose)).toMatchSnapshot();
+  });
+
+  it('should add a hard left class to the link when the noIndent prop is passed', () => {
+    const component = mount(<Disclose title='Some title' noIndent={ true }> <div>disclose this</div> </Disclose>);
+    expect(component.find('a').hasClass('hard--left')).toBe(true);
   });
 });


### PR DESCRIPTION
### Summary

Allow users to specify that they dont want the clickable caret `>` indented at all via the `noIndent` prop.

Example use case here:

<img width="568" alt="screen shot 2019-01-18 at 5 13 06 pm" src="https://user-images.githubusercontent.com/3718812/51420163-d9f5c700-1b44-11e9-889f-3a47c5d094d2.png">
