### PR TITLE
feat (TokensInput): Handle pasted content better and enable any addKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Major] (Breaking changes) Update <TokensInput> props form to handle addKeys more clearly and scalably.
+                             Removes `spacesAllowedInToken` prop in favor of `extraAddKeys`.
 - [Patch] Conditionally render <Popper> within <Dropdown> only when the children should be shown for performance reasons.
 - [Feature] Add Sortable component (#1115)
 

--- a/src/components/TokensInput/TokensInput.story.js
+++ b/src/components/TokensInput/TokensInput.story.js
@@ -31,7 +31,7 @@ class TokensInput extends React.Component {
   onChange = (tokens) => {
     this.setState({ tokens });
     this.props.onChange(tokens);
-  }
+  };
 
   render() {
     const { tokens, onChange, ...rest } = this.props; //eslint-disable-line
@@ -52,12 +52,12 @@ storiesOf('TokensInput', module)
   .add('Default', withInfo()(() => {
     return <TokensInput onChange={ action('tokens changed') } tokens={ SAMPLE_DATA }/>;
   }))
-  .add('spacesAllowedInToken', withInfo()(() => {
+  .add('with extraAddKeys', withInfo()(() => {
     return (
       <TokensInput
         onChange={ action('tokens changed') }
         tokens={ SAMPLE_DATA_WITH_SPACES }
-        spacesAllowedInToken={ true }
+        extraAddKeys={ [' ', '_', ';', '|', '.'] }
       />
     );
   }));

--- a/src/components/TokensInput/index.js
+++ b/src/components/TokensInput/index.js
@@ -64,6 +64,7 @@ export const TokensInput = ({
   /**
    * Render an OUI Token to display each token.
    * https://github.com/olahol/react-tagsinput#rendertag
+   *
    * @param {Object} renderOptions - Values to render token
    * @returns {ReactElement}
    */
@@ -74,6 +75,7 @@ export const TokensInput = ({
     const { name, style } = tag;
     return (
       <Token
+        key={ key }
         isDismissible={ true }
         onDismiss={ onDismiss }
         name={ name }
@@ -87,6 +89,8 @@ export const TokensInput = ({
   /**
    * Handler for when a string is pasted into the input.
    * Splits the string on all the addKeys and extraAddKeys.
+   * https://github.com/olahol/react-tagsinput#pastesplit
+   *
    * @param {string} str - The pasted string.
    * @returns {Array<string>}
    */
@@ -95,8 +99,8 @@ export const TokensInput = ({
       .map(k => k.match)
       .concat(extraAddKeys)
 
-      // Split the string by all our addKeys by joining with an
-      // \n which we will use as the final split operator.
+      // Split the string by all our addKeys by joining with a
+      // \n, which we will use as the final split operator.
       .reduce((acc, value) => acc.split(value).join('\n'), str)
       .split('\n')
       .filter(k => !!k);
@@ -154,7 +158,7 @@ TokensInput.propTypes = {
    * an intent to enter the current string as a new Token.
    * See ADD_KEYS above.
    */
-  extraAddKeys: PropTypes.arrayOf(PropTypes.number),
+  extraAddKeys: PropTypes.arrayOf([PropTypes.number, PropTypes.string]),
 
   maxTags: PropTypes.number,
 

--- a/src/components/TokensInput/index.js
+++ b/src/components/TokensInput/index.js
@@ -26,7 +26,13 @@ const ADD_KEYS = [
  * @param {Object} props - Properties passed to component
  * @returns {ReactElement}
  */
-export const TokensInput = ({tokens, spacesAllowedInToken, placeholder, onChange}) => {
+export const TokensInput = ({
+  maxTags,
+  onChange,
+  placeholder,
+  spacesAllowedInToken,
+  tokens,
+}) => {
   /**
    * Wrap the layout in a flexed <div>
    * https://github.com/olahol/react-tagsinput#renderlayout
@@ -72,16 +78,18 @@ export const TokensInput = ({tokens, spacesAllowedInToken, placeholder, onChange
    * @param {Array.<TokenWrapper|String>} allTokens - All tokens
    */
   function __onChange(allTokens) {
-    const updatedTokens = allTokens.reduce((acc, token) => {
-      // A newly typed token will be in string form
-      if (typeof token === 'string') {
-        token = { name: token };
-      }
-      if (!acc.find(item => item.name === token.name)) {
-        acc.push(token);
-      }
-      return acc;
-    }, []);
+    const updatedTokens = allTokens
+      .reduce((acc, token) => {
+        // A newly typed token will be in string form
+        if (typeof token === 'string') {
+          token = { name: token };
+        }
+        if (!acc.find(item => item.name === token.name)) {
+          acc.push(token);
+        }
+        return acc;
+      }, [])
+      .filter(token => !!token.name);
 
     onChange(updatedTokens);
   }
@@ -93,7 +101,7 @@ export const TokensInput = ({tokens, spacesAllowedInToken, placeholder, onChange
         addKeys={ ADD_KEYS.concat(spacesAllowedInToken ? [] : /** SPACE */ 32) }
         onlyUnique={ true }
         addOnPaste={ true }
-        maxTags={ 12 }
+        maxTags={ maxTags }
         onChange={ __onChange }
         renderTag={ renderToken }
         renderLayout={ renderLayout }

--- a/src/components/TokensInput/index.js
+++ b/src/components/TokensInput/index.js
@@ -160,8 +160,14 @@ TokensInput.propTypes = {
    */
   extraAddKeys: PropTypes.arrayOf([PropTypes.number, PropTypes.string]),
 
+  /**
+   * Maximum number of allowed tokens (pass-through to <ReactTagsInput>)
+   */
   maxTags: PropTypes.number,
 
+  /**
+   * Handler to invoke when the token list changes.
+   */
   onChange: PropTypes.func.isRequired,
 
   /**
@@ -182,8 +188,6 @@ TokensInput.defaultProps = {
   maxTags: -1,
 
   placeholder: 'enter tokens',
-
-  spacesAllowedInToken: false,
 };
 
 export default TokensInput;

--- a/src/components/TokensInput/tests/index.js
+++ b/src/components/TokensInput/tests/index.js
@@ -83,7 +83,16 @@ describe('components/TokensInput', () => {
 
         expect(mockOnChange).toBeCalled();
         expect(mockOnChange).toHaveBeenCalledWith(SAMPLE_DATA);
+      });
 
+      it('should not allow empty strings', () => {
+        const input = component.find('input');
+        input.simulate('change', { target: { value: '' }});
+        input.simulate('keyDown', { keyCode: 32 });
+        component.update();
+
+        expect(mockOnChange).toBeCalled();
+        expect(mockOnChange).toHaveBeenCalledWith(SAMPLE_DATA);
       });
     });
 

--- a/src/components/TokensInput/tests/index.js
+++ b/src/components/TokensInput/tests/index.js
@@ -84,23 +84,17 @@ describe('components/TokensInput', () => {
         expect(mockOnChange).toBeCalled();
         expect(mockOnChange).toHaveBeenCalledWith(SAMPLE_DATA);
       });
-
-      it('should not allow empty strings', () => {
-        const input = component.find('input');
-        input.simulate('change', { target: { value: '' }});
-        input.simulate('keyDown', { keyCode: 32 });
-        component.update();
-
-        expect(mockOnChange).toBeCalled();
-        expect(mockOnChange).toHaveBeenCalledWith(SAMPLE_DATA);
-      });
     });
 
-    describe('with spaces allowed', function() {
+    describe('with extra addKeys allowed', function() {
       beforeEach(function() {
         mockOnChange = jest.fn();
         component = mount(
-          <TokensInput onChange={ mockOnChange } tokens={ SAMPLE_DATA } spacesAllowedInToken={ true } />
+          <TokensInput
+            onChange={ mockOnChange }
+            tokens={ SAMPLE_DATA }
+            extraAddKeys={ [' ', '.', '_'] }
+          />
         );
       });
 
@@ -116,6 +110,21 @@ describe('components/TokensInput', () => {
         component.update();
 
         const expectedTokens = cloneDeep(SAMPLE_DATA).concat({ name: 'new token val' });
+        expect(mockOnChange).toBeCalled();
+        expect(mockOnChange).toHaveBeenCalledWith(expectedTokens);
+      });
+
+      it('should break up pasted strings based on the extra add keys', () => {
+        const input = component.find('input');
+        input.simulate('paste', { clipboardData: { getData: () => 'balloons_banana-smoothie   hotdogs' }});
+        // input.simulate('keyDown', { keyCode: 13 });
+        component.update();
+
+        const expectedTokens = cloneDeep(SAMPLE_DATA).concat([
+          { name: 'balloons' },
+          { name: 'banana-smoothie' },
+          { name: 'hotdogs' },
+        ]);
         expect(mockOnChange).toBeCalled();
         expect(mockOnChange).toHaveBeenCalledWith(expectedTokens);
       });


### PR DESCRIPTION
## Summary

A couple fixes for the `<TokensInput>` component:

*1. Enhancement* - Implement our own `pasteSplit ` method. This is necessary because the native one does not split based on the `addKeys` which have been specified. Its a little silly that we have to do this, but it makes the behavior consistent between typing and pasting.

*2. Bug Fix* - Pass the `maxTags` prop to the `<ReactTagsInput>` component instead of hardcoding 12.

BREAKING CHANGE
*3. Enhancement* - Allow any additional `addKeys` to be passed by the consumer via the  prop `extraAddKeys`. This change removes the specific `allowSpacesInTokens` in favor of `extraAddKeys`, which I discovered can be keyCodes or strings.

## Test Plan
Unit test added for new paste and `extraAddKeys` behavior.