### PR TITLE
perf fix (Popper): Conditionally render <Popper> based on open & disabled state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Conditionally render <Popper> within <Dropdown> only when the children should be shown for performance reasons.
 
 ## 40.15.0 - 2019-1-23
 - [Patch] Add -webkit vendor prefix for select

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -107,23 +107,25 @@ class Dropdown extends React.Component {
             })
           }
         </Target>
-        <Popper
-          placement={ placement }
-          className='oui-dropdown-children'
-          style={{
-            zIndex: zIndex,
-            position: 'absolute',
-            width: width,
-            marginTop: 2,
-            marginBottom: 2,
-            borderRadius: 'var(--border-radius)',
-            boxShadow: '0 2px 3px rgba(0,0,0,.1)',
-          }}
-          onMouseOver={ this.onMouseOver }
-          onMouseLeave={ this.onMouseLeave }
-          onClick={ this.handleToggle }>
-          { isOpen && !isDisabled && children }
-        </Popper>
+        {isOpen && !isDisabled &&
+          <Popper
+            placement={ placement }
+            className='oui-dropdown-children'
+            style={{
+              zIndex: zIndex,
+              position: 'absolute',
+              width: width,
+              marginTop: 2,
+              marginBottom: 2,
+              borderRadius: 'var(--border-radius)',
+              boxShadow: '0 2px 3px rgba(0,0,0,.1)',
+            }}
+            onMouseOver={ this.onMouseOver }
+            onMouseLeave={ this.onMouseLeave }
+            onClick={ this.handleToggle }>
+            {children}
+          </Popper>
+        }
       </Manager>
     );
   }

--- a/src/components/Dropdown/tests/__snapshots__/index.js.snap
+++ b/src/components/Dropdown/tests/__snapshots__/index.js.snap
@@ -39,33 +39,79 @@ exports[`components/Dropdown should include oui-form-bad-news class when display
 />
 `;
 
-exports[`components/Dropdown should not render children when isDisabled is true 1`] = `
-<withHandlers(withState(Dropdown))
+exports[`components/Dropdown should not render children or Popper when isDisabled is true 1`] = `
+<withState(withHandlers(withState(Dropdown)))
   arrowIcon="none"
   buttonContent="Dropdown"
   icon={true}
   idDisabled={true}
-  isOpen={false}
-  toggle={[Function]}
 >
-  <ul>
-    <li
-      key="0"
+  <withHandlers(withState(Dropdown))
+    arrowIcon="none"
+    buttonContent="Dropdown"
+    icon={true}
+    idDisabled={true}
+    isOpen={false}
+    toggle={[Function]}
+  >
+    <withState(Dropdown)
+      arrowIcon="none"
+      buttonContent="Dropdown"
+      hide={[Function]}
+      icon={true}
+      idDisabled={true}
+      isOpen={false}
+      show={[Function]}
+      toggle={[Function]}
     >
-      Manual
-    </li>
-    <li
-      key="1"
-    >
-      Maximize Conventions
-    </li>
-    <li
-      key="2"
-    >
-      Faster Results
-    </li>
-  </ul>
-</withHandlers(withState(Dropdown))>
+      <Dropdown
+        arrowIcon="none"
+        buttonContent="Dropdown"
+        hide={[Function]}
+        icon={true}
+        idDisabled={true}
+        isOpen={false}
+        overChildren={false}
+        setOverChildren={[Function]}
+        show={[Function]}
+        toggle={[Function]}
+      >
+        <Manager
+          className="oui-dropdown-group"
+          data-ui-component={true}
+          tag="div"
+        >
+          <div
+            className="oui-dropdown-group"
+            data-ui-component={true}
+          >
+            <Target>
+              <div>
+                <button
+                  className="oui-button"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className="flex"
+                  >
+                    <div
+                      className="flex--1 truncate"
+                    >
+                      Dropdown
+                    </div>
+                  </div>
+                </button>
+              </div>
+            </Target>
+          </div>
+        </Manager>
+      </Dropdown>
+    </withState(Dropdown)>
+  </withHandlers(withState(Dropdown))>
+</withState(withHandlers(withState(Dropdown)))>
 `;
 
 exports[`components/Dropdown should not use .oui-arrow-inline--down when icon isEqual to triangle 1`] = `

--- a/src/components/Dropdown/tests/index.js
+++ b/src/components/Dropdown/tests/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Dropdown from '../index';
 import { mount, shallow } from 'enzyme';
-import { shallowToJson } from 'enzyme-to-json';
+import { mountToJson, shallowToJson } from 'enzyme-to-json';
 
 const data = [
   {title: 'Manual', description: 'Dolcelatte cheeseburger swiss paneer cow gouda edam cheese slices'},
@@ -30,10 +30,11 @@ describe('components/Dropdown', () => {
 
     expect(component.find('Dropdown').props().isOpen).toBe(true);
     expect(component.find('ul').exists()).toBe(true);
+    expect(component.find('Popper').exists()).toBe(true);
   });
 
-  it('should not render children when isDisabled is true', () => {
-    const component = shallow(
+  it('should not render children or Popper when isDisabled is true', () => {
+    const component = mount(
       <Dropdown
         icon={ true }
         buttonContent='Dropdown'
@@ -48,7 +49,8 @@ describe('components/Dropdown', () => {
         </ul>
       </Dropdown>
     );
-    expect(shallowToJson(component)).toMatchSnapshot();
+    expect(mountToJson(component)).toMatchSnapshot();
+    expect(component.find('Popper').exists()).toBe(false);
   });
 
   it('should call the child onClick handler when clicked', () => {


### PR DESCRIPTION
## Summary

Popper is quite a JS intensive utility, which, among other things, binds to page scroll in every instance in order to know when to reposition itself.

It's currently instantiated regardless of whether or not its shown, making places with hundreds of <Dropdowns> on the page at once have performance issues.

This PR updates it to only render `<Popper>` when it should.