### PR TITLE
Drau/emptystate remove css filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Fix design debt and remove CSS to tint EmptyDashboard images
 
 ## 40.15.0 - 2019-1-23
 - [Patch] Add -webkit vendor prefix for select

--- a/src/components/EmptyDashboard/index.js
+++ b/src/components/EmptyDashboard/index.js
@@ -29,7 +29,7 @@ const EmptyDashboard = ({
               <object
                 data={ imagePath }
                 className="svg--non-scaling-stroke display--inline"
-                style={{ maxWidth: '450px', maxHeight: '290px', 'filter': 'hue-rotate(33deg) saturate(130%)' }}
+                style={{ maxWidth: '450px', maxHeight: '290px' }}
                 data-test-section={ testSection && `${testSection}-image` }
                 alt=""
               />


### PR DESCRIPTION
Removing this CSS filter to (coincide with updating the empty state SVG source colors)[https://github.com/optimizely/optimizely/pull/9040] to the updated rebrand color palette. 