### PR TITLE
feat(TokensInput)[REC-751][REC-760][REC-762]: Added addOnBlur, flexing, minWidth, and placeholder with maxTags for input of TokensInput.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
-- [Feature] Add inputStyle prop and logic with maxTags for input of TokensInput
+- [Feature] Add onBlur, flexing, and logic with maxTags and placeholder for input of TokensInput
 - [Patch] Update webpack-dev-server to fix vulnerability issue
 - [Patch] Fix design debt and remove CSS to tint EmptyDashboard images
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Feature] Add inputStyle prop and logic with maxTags for input of TokensInput
 - [Patch] Update webpack-dev-server to fix vulnerability issue
 - [Patch] Fix design debt and remove CSS to tint EmptyDashboard images
 

--- a/src/components/TokensInput/index.js
+++ b/src/components/TokensInput/index.js
@@ -40,6 +40,7 @@ const ADD_KEYS = [
  */
 export const TokensInput = ({
   extraAddKeys,
+  inputStyle,
   maxTags,
   onChange,
   placeholder,
@@ -129,6 +130,7 @@ export const TokensInput = ({
   }
 
   const addKeys = ADD_KEYS.map(k => k.keyCode).concat(extraAddKeys);
+  const isNumberOfTokensMoreThanOrEqualToMaxTags = tokens.length >= maxTags;
 
   return (
     <div className="oui-text-input text--left flush">
@@ -136,8 +138,9 @@ export const TokensInput = ({
         addKeys={ addKeys }
         addOnPaste={ true }
         inputProps={{
-          className: 'soft-half--ends soft--sides no-border width--150',
+          className: `${inputStyle} soft-half--ends soft--sides no-border width--150`,
           placeholder,
+          readonly: isNumberOfTokensMoreThanOrEqualToMaxTags ? 'true' : false,
         }}
         maxTags={ maxTags }
         onChange={ __onChange }
@@ -159,6 +162,11 @@ TokensInput.propTypes = {
    * See ADD_KEYS above.
    */
   extraAddKeys: PropTypes.arrayOf([PropTypes.number, PropTypes.string]),
+
+  /**
+   * Additional styling for the input field.
+   */
+  inputStyle: PropTypes.string,
 
   /**
    * Maximum number of allowed tokens (pass-through to <ReactTagsInput>)

--- a/src/components/TokensInput/index.js
+++ b/src/components/TokensInput/index.js
@@ -141,7 +141,7 @@ export const TokensInput = ({
         inputProps={{
           className: `flex flex--1 ${minWidth} no-border soft-half--ends soft--sides`,
           placeholder: isNumberOfTokensMoreThanOrEqualToMaxTags ? '' : placeholder,
-          readonly: isNumberOfTokensMoreThanOrEqualToMaxTags ? 'true' : false,
+          readOnly: isNumberOfTokensMoreThanOrEqualToMaxTags,
         }}
         maxTags={ maxTags }
         onChange={ __onChange }

--- a/src/components/TokensInput/index.js
+++ b/src/components/TokensInput/index.js
@@ -40,7 +40,6 @@ const ADD_KEYS = [
  */
 export const TokensInput = ({
   extraAddKeys,
-  inputStyle,
   maxTags,
   onChange,
   placeholder,
@@ -130,16 +129,18 @@ export const TokensInput = ({
   }
 
   const addKeys = ADD_KEYS.map(k => k.keyCode).concat(extraAddKeys);
-  const isNumberOfTokensMoreThanOrEqualToMaxTags = tokens.length >= maxTags;
+  const isNumberOfTokensMoreThanOrEqualToMaxTags = tokens.length >= maxTags && maxTags !== -1;
+  const minWidth = isNumberOfTokensMoreThanOrEqualToMaxTags ? '' : 'min-width--150';
 
   return (
     <div className="oui-text-input text--left flush">
       <ReactTagsInput
         addKeys={ addKeys }
+        addOnBlur={ true }
         addOnPaste={ true }
         inputProps={{
-          className: `${inputStyle} soft-half--ends soft--sides no-border width--150`,
-          placeholder,
+          className: `flex flex--1 ${minWidth} no-border soft-half--ends soft--sides`,
+          placeholder: isNumberOfTokensMoreThanOrEqualToMaxTags ? '' : placeholder,
           readonly: isNumberOfTokensMoreThanOrEqualToMaxTags ? 'true' : false,
         }}
         maxTags={ maxTags }
@@ -162,11 +163,6 @@ TokensInput.propTypes = {
    * See ADD_KEYS above.
    */
   extraAddKeys: PropTypes.arrayOf([PropTypes.number, PropTypes.string]),
-
-  /**
-   * Additional styling for the input field.
-   */
-  inputStyle: PropTypes.string,
 
   /**
    * Maximum number of allowed tokens (pass-through to <ReactTagsInput>)

--- a/src/components/TokensInput/tests/index.js
+++ b/src/components/TokensInput/tests/index.js
@@ -55,26 +55,55 @@ describe('components/TokensInput', () => {
     });
   });
 
-  describe('when rendering tokens with inputStyle, maxTags, and placeholder', function() {
-    const inputCSS = '.flex .flex--1 .soft-half--ends .soft--sides .no-border .width--150';
+  describe('when rendering tokens with optional props', function() {
+    describe('when optional prop is placeholder', function() {
+      const inputCSS = '.flex .flex--1 .min-width--150 .no-border .soft-half--ends .soft--sides';
 
-    beforeEach(function() {
-      mockOnChange = jest.fn();
-      component = mount(
-        <TokensInput
-          inputStyle='flex flex--1'
-          maxTags={ 5 }
-          placeholder='keywords'
-          onChange={ mockOnChange }
-          tokens={ SAMPLE_DATA }
-        />
-      );
+      beforeEach(function() {
+        mockOnChange = jest.fn();
+        component = mount(
+          <TokensInput
+            placeholder='keywords'
+            onChange={ mockOnChange }
+            tokens={ SAMPLE_DATA }
+          />
+        );
+      });
+
+      afterEach(function() {
+        component.unmount();
+      });
+
+      it('should SHOW input has custom placeholder', function() {
+        expect(component.find('Token').length).toBe(5);
+        expect(component.find(inputCSS).props().readonly).toBe(false);
+        expect(component.find(inputCSS).props().placeholder).toBe('keywords');
+      });
     });
 
-    it('should SHOW input is readonly if the number of tokens is not less than the value of maxTags', function() {
-      expect(component.find('Token').length).toBe(5);
-      expect(component.find(inputCSS).props().readonly).toBe('true');
-      expect(component.find(inputCSS).props().placeholder).toBe('keywords');
+    describe('when optional prop is maxTags', function() {
+      const inputCSS = '.flex .flex--1 .no-border .soft-half--ends .soft--sides';
+
+      beforeEach(function() {
+        mockOnChange = jest.fn();
+        component = mount(
+          <TokensInput
+            maxTags={ 5 }
+            onChange={ mockOnChange }
+            tokens={ SAMPLE_DATA }
+          />
+        );
+      });
+
+      afterEach(function() {
+        component.unmount();
+      });
+
+      it('should SHOW input is readonly if the number of tokens is not less than the value of maxTags', function() {
+        expect(component.find('Token').length).toBe(5);
+        expect(component.find(inputCSS).props().readonly).toBe('true');
+        expect(component.find(inputCSS).props().placeholder).toBe('');
+      });
     });
   });
 

--- a/src/components/TokensInput/tests/index.js
+++ b/src/components/TokensInput/tests/index.js
@@ -16,6 +16,12 @@ describe('components/TokensInput', () => {
   let component;
   let mockOnChange;
 
+  afterEach(function() {
+    if (component) {
+      component.unmount();
+    }
+  });
+
   describe('rendering tokens', function() {
     beforeEach(function() {
       mockOnChange = jest.fn();
@@ -23,6 +29,7 @@ describe('components/TokensInput', () => {
         <TokensInput onChange={ mockOnChange } tokens={ SAMPLE_DATA } />
       );
     });
+
     function assertTokenRender(comp, style, font, text) {
       expect(comp.find('[data-test-section="token"]').hasClass('oui-token-wrap')).toBe(true);
       expect(comp.find(`[data-test-section="token"] div.oui-token--${style}`).length).toBe(1);
@@ -70,10 +77,6 @@ describe('components/TokensInput', () => {
         );
       });
 
-      afterEach(function() {
-        component.unmount();
-      });
-
       it('should SHOW input has custom placeholder', function() {
         expect(component.find('Token').length).toBe(5);
         expect(component.find(inputCSS).props().readOnly).toBe(false);
@@ -93,10 +96,6 @@ describe('components/TokensInput', () => {
             tokens={ SAMPLE_DATA }
           />
         );
-      });
-
-      afterEach(function() {
-        component.unmount();
       });
 
       it('should SHOW input is readonly if the number of tokens is not less than the value of maxTags', function() {

--- a/src/components/TokensInput/tests/index.js
+++ b/src/components/TokensInput/tests/index.js
@@ -76,7 +76,7 @@ describe('components/TokensInput', () => {
 
       it('should SHOW input has custom placeholder', function() {
         expect(component.find('Token').length).toBe(5);
-        expect(component.find(inputCSS).props().readonly).toBe(false);
+        expect(component.find(inputCSS).props().readOnly).toBe(false);
         expect(component.find(inputCSS).props().placeholder).toBe('keywords');
       });
     });
@@ -101,7 +101,7 @@ describe('components/TokensInput', () => {
 
       it('should SHOW input is readonly if the number of tokens is not less than the value of maxTags', function() {
         expect(component.find('Token').length).toBe(5);
-        expect(component.find(inputCSS).props().readonly).toBe('true');
+        expect(component.find(inputCSS).props().readOnly).toBe(true);
         expect(component.find(inputCSS).props().placeholder).toBe('');
       });
     });

--- a/src/components/TokensInput/tests/index.js
+++ b/src/components/TokensInput/tests/index.js
@@ -55,6 +55,29 @@ describe('components/TokensInput', () => {
     });
   });
 
+  describe('when rendering tokens with inputStyle, maxTags, and placeholder', function() {
+    const inputCSS = '.flex .flex--1 .soft-half--ends .soft--sides .no-border .width--150';
+
+    beforeEach(function() {
+      mockOnChange = jest.fn();
+      component = mount(
+        <TokensInput
+          inputStyle='flex flex--1'
+          maxTags={ 5 }
+          placeholder='keywords'
+          onChange={ mockOnChange }
+          tokens={ SAMPLE_DATA }
+        />
+      );
+    });
+
+    it('should SHOW input is readonly if the number of tokens is not less than the value of maxTags', function() {
+      expect(component.find('Token').length).toBe(5);
+      expect(component.find(inputCSS).props().readonly).toBe('true');
+      expect(component.find(inputCSS).props().placeholder).toBe('keywords');
+    });
+  });
+
   describe('entering tokens', function() {
     describe('with the default addKeys', function() {
       beforeEach(function() {


### PR DESCRIPTION
### **Summary**:
**Feature**: 
- Added `addOnBlur={ true }` for ReactTagsInput to allow creating token on blur or when lost focus.
- Added `.flex .flex--1 .min-width-150` to style the input field of the `TokensInput`.
- Added `readOnly` as an attribute in the input field of `TokensInput` component to disable all typing except `Delete` if the number of tokens reaches the `maxTags` limit. Also change the `placeholder` of
- When the number of tokens reaches the `maxTags` limit:
  - `readOnly: true`
  - `placeholder: ""`
  - `remove min-width-150`
- Upon deleting/removing tokens, the input field will be enabled again.

**These changes are required for the attached bugs in the Adaptive Audience projects.**

**Audience Builder**:
  - **Before**:
    - without `addOnBlur`
![image](https://user-images.githubusercontent.com/16441804/53121772-d79ed800-3509-11e9-8b18-e21d7e7e9880.png)
    - without `flexing, minWidth, placeholder`
![image](https://user-images.githubusercontent.com/16441804/53061232-0c5f5080-3472-11e9-8853-bd7815fe05c4.png)

  - **After**:
    - with `addOnBlur`
![image](https://user-images.githubusercontent.com/16441804/53121741-bb02a000-3509-11e9-8827-8c6e087607ae.png)
    - with `flexing, minWidth, placeholder`
![image](https://user-images.githubusercontent.com/16441804/53124604-a4137c00-3510-11e9-8b8a-f9e67a11abb7.png)

### **Test Plan:**
- Verified by Manual tests on Browser and Unit-tests.

### **JIRA Issues:**
- [REC-751](https://optimizely.atlassian.net/browse/REC-751)
- [REC-760](https://optimizely.atlassian.net/browse/REC-760)
- [REC-762](https://optimizely.atlassian.net/browse/REC-762)

Signed-off-by: Son Pham <son.pham@optimizely.com>