### PR TITLE
Encode hex `#` character as `%23` encoded character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Add encodecolor() SASS function to convert `#` character to `%23` encoded entity to fix Chrome update breaking `#hexcolor` use in inline `<svg>` background image with `$var-color`
 
 ## 42.1.0 - 2019-02-20
 - [Feature] Add onBlur, flexing, and logic with maxTags and placeholder for input of TokensInput (#1123)

--- a/src/components/RangeSlider/Rangeslider.story.js
+++ b/src/components/RangeSlider/Rangeslider.story.js
@@ -17,13 +17,9 @@ stories
 
 stories.add('default', withInfo()(() => {
   return (
-    <div>
-      <input type="text" className="oui-text-input push-double--bottom" />
-      <RangeSlider
-        value={ number('value', 50) }
-      />
-      <input type="text" className="oui-text-input" />
-    </div>
+    <RangeSlider
+      value={ number('value', 50) }
+    />
   );
 }))
   .add('disabled', withInfo()(() => {

--- a/src/components/RangeSlider/index.scss
+++ b/src/components/RangeSlider/index.scss
@@ -60,7 +60,7 @@
   }
   .range-display {
     height: 35px;
-    background-image: url('data:image/svg+xml;utf-8,<svg preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256"><path fill="'+map-fetch($rangeslider, background-color)+'" d="M0 256h256V0z"/></svg>');
+    background-image: url('data:image/svg+xml;utf-8,<svg preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256"><path fill="'+encodecolor(map-fetch($rangeslider, background-color))+'" d="M0 256h256V0z"/></svg>');
     background-size: 100% 100%;
     background-repeat: no-repeat;
     position: absolute;

--- a/src/oui/partials/sass/_functions.scss
+++ b/src/oui/partials/sass/_functions.scss
@@ -63,3 +63,15 @@
 @function shade($color, $percentage) {
   @return mix(black, $color, $percentage);
 }
+
+
+/// Replace #hex with %23hex for valid use inside <svg>
+
+@function encodecolor($string) {
+	@if type-of($string) == 'color' {
+    $hex: str-slice(ie-hex-str($string), 4);
+    $string:unquote("#{$hex}");
+	}
+  $string: '%23' + $string;
+	@return $string;
+}


### PR DESCRIPTION
Chrome updated and broke some functionality that allowed `#` in an inline svg background. This fix encodes `#` as `%23` so the graphic works as expected.

Before:
<img width="1552" alt="screen shot 2019-02-21 at 4 12 32 pm" src="https://user-images.githubusercontent.com/16581943/53212404-a6053a00-35f9-11e9-82f1-958160fca72e.png">

After:
<img width="1552" alt="screen shot 2019-02-21 at 4 12 45 pm" src="https://user-images.githubusercontent.com/16581943/53212407-a998c100-35f9-11e9-96f7-76141973c00b.png">
