### PR TITLE
fix (OUI) Lockdown highlight.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "awesome-debounce-promise": "^1.0.0",
     "classnames": "^2.2.5",
     "clipboard": "^1.5.12",
-    "highlight.js": "^9.5.0",
+    "highlight.js": "9.5.0",
     "immutable": "3.x.x",
     "lodash.debounce": "^4.0.8",
     "lodash.noop": "^3.0.1",


### PR DESCRIPTION
## Summary

Installing the latest version of OUI fails to install for Program Management. Probably because we're not using yarn and running node version 6. The failure occurs when OUI attempts to install `highlight.js` version `9.15.2` (a buggy version of highlight.js)

This PR locks down the `highlight.js` dependency to version `9.5.0`

## Test Plan

Running `npm i optimizely-oui@40.14.0` locally
