### PR TITLE
patch(Select): Fixed Select export by exporting it in src/main.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 ## Unreleased
 - [Patch] Update <Steps> styling to have an outline for the Active step and filled circles for Complete steps
 
+### Fixed
+- [Patch] Fixed <Select> export by exporting it in src/main.js
+
 ## 42.2.1 - 2019-02-25
   - [Patch] Lockdown highlight.js dependency to version 9.5.0
 

--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,7 @@ export { default as Popover } from './components/Popover';
 export { default as Poptip } from './components/Poptip';
 export { default as Radio } from './components/Radio';
 export { default as RangeSlider } from './components/RangeSlider';
+export { default as Select } from './components/Select';
 export { default as SelectDropdown } from './components/SelectDropdown';
 export { default as Sidebar } from './components/Sidebar';
 export { default as Sortable } from './components/Sortable';


### PR DESCRIPTION
# Summary
Select component exists in the OUI code base but was not being exported. This PR fixes this issue by exporting it inside `src/main.js` 

### The Following File include changes for the fix
1. `src/main.js`

### Updated CHANGELOG 
