### PR TITLE
patch(SelectDropdown): Fixed a Crash when value is not the items list.

### DIFF
--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -119,7 +119,7 @@ class SelectDropdown extends React.Component {
       {['oui-form-bad-news']: this.props.displayError}
     );
 
-    const activatorLabel = selectedItem.activatorLabel || selectedItem.label;
+    const activatorLabel = !!selectedItem ? (selectedItem.activatorLabel || selectedItem.label) : '';
 
     return (
       <Dropdown


### PR DESCRIPTION
# Summary
SelectDropdown crashes when
1. The given `value` is not found in the list of `items`
2. The list of `items` provided is empty.

# Fix
In both the above cases, the selected value will now be empty and it would not crash the page anymore.