### PR TITLE
feat (OverlayWrapper) Adding attachmentConstraint prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 - [Patch] Fixed the `isRequired` prop on **Input** component which wasn't working as expected ([#1136](https://github.com/optimizely/oui/pull/1136))
 
 ## 42.3.0 - 2019-03-08
-- [Feature] Fixed Select export by including in src/main.js.
+- [Feature] Add attachmentConstraint prop to OverlayWrapper component.
+- [Feature] Fixed <Select> export by including in src/main.js.
 - [Patch] Update ArrowInline default arrow direction to down
 - [Patch] Update Dropdown component to remove arrowIcon `true` option
 - [Patch] Update Steps styling to have an outline for the Active step and filled circles for Complete steps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 
 ## Unreleased
 - [Patch] Update node for running tests/builds to v10.15.3 - travis CI pulls the node version from the updated .nvmrc
+- [Patch] Add attachmentConstraint prop to OverlayWrapper component.
 
 ## 42.6.0 - 2019-04-12
 - [Feature] Update **Dialog** component to be a smaller, quick action dialog for user acknowledgment or a few inputs ([#1134](https://github.com/optimizely/oui/pull/1134))
@@ -20,8 +21,7 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 - [Patch] Fixed the `isRequired` prop on **Input** component which wasn't working as expected ([#1136](https://github.com/optimizely/oui/pull/1136))
 
 ## 42.3.0 - 2019-03-08
-- [Feature] Add attachmentConstraint prop to OverlayWrapper component.
-- [Feature] Fixed <Select> export by including in src/main.js.
+- [Feature] Fixed Select export by including in src/main.js.
 - [Patch] Update ArrowInline default arrow direction to down
 - [Patch] Update Dropdown component to remove arrowIcon `true` option
 - [Patch] Update Steps styling to have an outline for the Active step and filled circles for Complete steps

--- a/src/components/HelpPopover/tests/__snapshots__/index.js.snap
+++ b/src/components/HelpPopover/tests/__snapshots__/index.js.snap
@@ -2,6 +2,7 @@
 
 exports[`components/HelpPopover renders correctly 1`] = `
 <OverlayWrapper
+  attachmentConstraint="together"
   behavior="click"
   horizontalAttachment="center"
   isConstrainedToScreen={true}

--- a/src/components/OverlayWrapper/index.js
+++ b/src/components/OverlayWrapper/index.js
@@ -32,7 +32,7 @@ class OverlayWrapper extends React.Component {
       attachment: `${this.props.verticalAttachment} ${this.props.horizontalAttachment}`,
       constraints: [{
         to: 'window',
-        attachment: 'together',
+        attachment: this.props.attachmentConstraint,
         pin: this.props.isConstrainedToScreen,
       }],
     };
@@ -249,6 +249,8 @@ class OverlayWrapper extends React.Component {
 }
 
 OverlayWrapper.propTypes = {
+  /** Determines how the attachment is constrainted to the target */
+  attachmentConstraint: PropTypes.string,
   /** Event to listen to and open the overlay */
   behavior: PropTypes.oneOf(['click', 'hover']),
   /** Element that the `overlay` should attach to */
@@ -279,6 +281,7 @@ OverlayWrapper.propTypes = {
 };
 
 OverlayWrapper.defaultProps = {
+  attachmentConstraint: 'together',
   behavior: 'click',
   isConstrainedToScreen: false,
   shouldHideOnClick: true,

--- a/src/components/OverlayWrapper/index.js
+++ b/src/components/OverlayWrapper/index.js
@@ -249,7 +249,7 @@ class OverlayWrapper extends React.Component {
 }
 
 OverlayWrapper.propTypes = {
-  /** Determines how the attachment is constrainted to the target */
+  /** Determines how the attachment is constrained to the target */
   attachmentConstraint: PropTypes.oneOf(['both', 'element', 'none', 'target', 'together']),
   /** Event to listen to and open the overlay */
   behavior: PropTypes.oneOf(['click', 'hover']),

--- a/src/components/OverlayWrapper/index.js
+++ b/src/components/OverlayWrapper/index.js
@@ -250,7 +250,7 @@ class OverlayWrapper extends React.Component {
 
 OverlayWrapper.propTypes = {
   /** Determines how the attachment is constrainted to the target */
-  attachmentConstraint: PropTypes.string,
+  attachmentConstraint: PropTypes.oneOf(['both', 'element', 'none', 'target', 'together']),
   /** Event to listen to and open the overlay */
   behavior: PropTypes.oneOf(['click', 'hover']),
   /** Element that the `overlay` should attach to */

--- a/src/components/OverlayWrapper/tests/__snapshots__/index.js.snap
+++ b/src/components/OverlayWrapper/tests/__snapshots__/index.js.snap
@@ -2,6 +2,7 @@
 
 exports[`components/OverlayWrapper snapshots & others should render a Popover component inside 1`] = `
 <OverlayWrapper
+  attachmentConstraint="together"
   behavior="click"
   horizontalAttachment="center"
   isConstrainedToScreen={false}

--- a/src/components/OverlayWrapper/tests/index.js
+++ b/src/components/OverlayWrapper/tests/index.js
@@ -62,7 +62,7 @@ describe('components/OverlayWrapper when componentDidMount', () => {
   it('should pass the correct options when all the layout props are provided', () => {
     const component = mountComponentAndSubscribeToBodyReady(
       <OverlayWrapper
-        attachmentConstraint="bottom"
+        attachmentConstraint="none"
         overlay={ <TestPopover /> }
         horizontalAttachment="center"
         verticalAttachment="top"
@@ -78,7 +78,7 @@ describe('components/OverlayWrapper when componentDidMount', () => {
       expect(tetherOptions.attachment).toBe('top center');
       expect(tetherOptions.constraints.length).toBe(1);
       expect(tetherOptions.constraints[0]).toEqual({
-        attachment: 'bottom',
+        attachment: 'none',
         to: 'window',
         pin: true,
       });

--- a/src/components/OverlayWrapper/tests/index.js
+++ b/src/components/OverlayWrapper/tests/index.js
@@ -62,6 +62,7 @@ describe('components/OverlayWrapper when componentDidMount', () => {
   it('should pass the correct options when all the layout props are provided', () => {
     const component = mountComponentAndSubscribeToBodyReady(
       <OverlayWrapper
+        attachmentConstraint="bottom"
         overlay={ <TestPopover /> }
         horizontalAttachment="center"
         verticalAttachment="top"
@@ -77,7 +78,7 @@ describe('components/OverlayWrapper when componentDidMount', () => {
       expect(tetherOptions.attachment).toBe('top center');
       expect(tetherOptions.constraints.length).toBe(1);
       expect(tetherOptions.constraints[0]).toEqual({
-        attachment: 'together',
+        attachment: 'bottom',
         to: 'window',
         pin: true,
       });


### PR DESCRIPTION
## Summary

Adding an `attachmentConstraint` prop to the `OverlayWrapper`. This prop will allow a consumer to set how the attachment is constrained to the target.

For example, tethr will reposition the popover on scroll

![popover_issue](https://user-images.githubusercontent.com/41028823/56149009-306e7800-5f71-11e9-9d52-5aac25498bca.gif)

This fix for this issue , would be to set the `attachmentConstraint` to `bottom`

## Test Plan

Run the test suite `npm test`

I also tested this within [optly-components](https://github.com/optimizely/optly-components) using `npm link`

## Jira Issues

https://optimizely.atlassian.net/browse/MGMT-1917

