### PR TITLE
Update travis.yml to include node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 cache: yarn
+node_js: 10.15.3
 after_script:
 - npm run codecov
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 ## Unreleased
 - [Patch] Include node version inside travis.yml
 
+## 42.8.0 - 2019-05-02
+- [Feature] Add `copyButtonStyle` prop to **Code** component, and `style` prop to **CopyButton** component ([#1152](https://github.com/optimizely/oui/pull/1152))
+- [Patch] Update positioning for the **Sheet** body content ([#1148](https://github.com/optimizely/oui/pull/1148))
+
+ ## 42.7.0 - 2019-04-19
+- [Feature] Add **Date Picker** component, for single date selection, and **Date Range Picker** component, for selecting a start and end date ([#1140](https://github.com/optimizely/oui/pull/1140))
+
+ ## 42.6.2 - 2019-04-17
+- [Patch] Include id, name (as CamelCase), and friendlyName (with space etc) for Axiom color tool consumption ([#1147](https://github.com/optimizely/oui/pull/1147))
+- [Patch] Fix token order rendering when token is not draggable.
+
 ## 42.6.1 - 2019-04-15
 - [Patch] Update node for running tests/builds to v10.15.3 - travis CI pulls the node version from the updated .nvmrc
 - [Patch] Add attachmentConstraint prop to OverlayWrapper component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
-
-## 42.8.0 - 2019-05-02
-- [Feature] Add `copyButtonStyle` prop to **Code** component, and `style` prop to **CopyButton** component ([#1152](https://github.com/optimizely/oui/pull/1152))
-- [Patch] Update positioning for the **Sheet** body content ([#1148](https://github.com/optimizely/oui/pull/1148))
-
-## 42.7.0 - 2019-04-19
-- [Feature] Add **Date Picker** component, for single date selection, and **Date Range Picker** component, for selecting a start and end date ([#1140](https://github.com/optimizely/oui/pull/1140))
-
-## 42.6.2 - 2019-04-17
-- [Patch] Include id, name (as CamelCase), and friendlyName (with space etc) for Axiom color tool consumption ([#1147](https://github.com/optimizely/oui/pull/1147))
-- [Patch] Fix token order rendering when token is not draggable.
+- [Patch] Include node version inside travis.yml
 
 ## 42.6.1 - 2019-04-15
 - [Patch] Update node for running tests/builds to v10.15.3 - travis CI pulls the node version from the updated .nvmrc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Then you can run and develop locally:
 ### :bulb: Adopt Storybook Driven Development
 Storybook is the best way to learn about, play with, prototype, and build OUI components. Storybook runs locally and will watch for component and documentation updates. Visit http://storybooks-official.netlify.com/ for inspiration on all that is possible!
 
-Every component should contain prop definitions and a robust set of Storybook examples (stories). This will allow for quicker adoption and help Storybook to serve as the best hub for OUI technical documentation. **If you create or update a component, it shouldn't be considered finished until you've completed the following:**  
+Every component should contain prop definitions and a robust set of Storybook examples (stories). This will allow for quicker adoption and help Storybook to serve as the best hub for OUI technical documentation. **If you create or update a component, it shouldn't be considered finished until you've completed the following:**
 
 1. Run Storybook and watch assets via `yarn storybook`
 2. Copy or reference the Story format of this [ExampleComponent](./data/components/ExampleComponent)
@@ -42,7 +42,7 @@ Every component should contain prop definitions and a robust set of Storybook ex
 
 4. Verify your OUI changes work as expected in the Optimizely repo.
 
-    Use yarn link: 
+    Use yarn link:
 
     ```sh
     cd ~/projects/optimizely-oui    # go into package directory
@@ -84,10 +84,6 @@ Both UI Engineers and the Frontend team have permission to release OUI via `yarn
     * Paste in new release contributions from the `CHANGELOG.md` release notes section from step 3 above into the Description field
     * Click Publish Release
 8. Bump the OUI version number in Optimizely's [`package.json`](https://github.com/optimizely/optimizely/blob/devel/src/www/frontend/package.json) and [test to ensure compatibility](https://docs.google.com/document/d/1TTfdhCSH7mPBeUzVme99qHR-QsFg7PTKP2lGqB9Dk3Y/edit#heading=h.ktasdjfn5j1h).
-    * For a Minor bump: in the Optimizely repo run `yarn upgrade optimizely-oui`, which will update the version in the `yarn.lock` file
-        * For a Major bump
-            - Run `yarn upgrade optimizely-oui@[version #]`, which will update the version in the `yarn.lock` file
-            - Ex: `yarn upgrade optimizely-oui@43.x.x`
+    * Within the Optimizely repo run `yarn upgrade optimizely-oui@xx.xx.xx` to update the version numbers referenced in `yarn.lock` and `package.json`
     * Make a PR that links to the OUI release and includes descriptions of the issues fixed and the JIRA ticket numbers for the fixes in this release
-        - You should expect to see the yarn.lock file changed
 9. You're done :sunglasses:


### PR DESCRIPTION
After bumping OUI in this PR (https://github.com/optimizely/optimizely/pull/9777), Travis.ci is failing to use the correct nvm version when running `yarn install` for OUI, so this PR should hopefully fix the Travis error:
https://travis-ci.com/optimizely/optimizely/jobs/197570116