### PR TITLE
Remove cache for yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-cache: yarn
+cache: bundler
 node_js: 10.15.3
 after_script:
 - npm run codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 
 ## Unreleased
 
+- [Patch] Disable yarn cache for travis.yml
+
 ## 42.8.1 - 2019-05-02
 - [Patch] Include node version inside travis.yml
 


### PR DESCRIPTION
By using `cache: bundler` we force Travis to clear the yarn cache to avoid build issues:
https://docs.travis-ci.com/user/caching/