### PR TITLE
feat(Textarea) Adding MinHeight prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Feature] Add `minHeight` prop to **Textarea** component ([#1159](https://github.com/optimizely/oui/pull/1159))
 
 ## 42.8.3 - 2019-05-06
 - [Patch] Fix regression caused by react-popper upgrade ([#1158](https://github.com/optimizely/oui/pull/1158))

--- a/src/components/Textarea/Textarea.story.js
+++ b/src/components/Textarea/Textarea.story.js
@@ -22,6 +22,7 @@ stories
     return (
       <div>
         <Textarea
+          minHeight={ number('minHeight', 250) }
           isDisabled={ boolean('isDisabled', false) }
           defaultValue='Delete this default value and see the placeholder'
           maxLength={ number('maxLength', 250) }

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -41,7 +41,7 @@ class Textarea extends React.Component {
     return (
       /* eslint-disable react/jsx-no-bind */
       <textarea
-        style={ { minHeight: minHeight } }
+        style={{ minHeight: minHeight }}
         data-oui-component={ true }
         className={ classes }
         ref={ (c) => { this._textarea = c; } }

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -23,6 +23,7 @@ class Textarea extends React.Component {
     isRequired,
     isDisabled,
     maxLength,
+    minHeight,
     onBlur,
     onChange,
     onFocus,
@@ -40,6 +41,7 @@ class Textarea extends React.Component {
     return (
       /* eslint-disable react/jsx-no-bind */
       <textarea
+        style={ { minHeight: minHeight } }
         data-oui-component={ true }
         className={ classes }
         ref={ (c) => { this._textarea = c; } }
@@ -133,6 +135,10 @@ Textarea.propTypes = {
    * Max length of the input value
    */
   maxLength: PropTypes.number,
+  /**
+   * Min height of the text area
+   */
+  minHeight: PropTypes.number,
   /** Form note for the input */
   note: PropTypes.string,
   /**
@@ -165,6 +171,7 @@ Textarea.defaultProps = {
   label: null,
   note: null,
   isOptional: false,
+  minHeight: null,
 };
 
 export default Textarea;


### PR DESCRIPTION
# Summary
Added an optional prop to set minimum height of textarea.

### The Following File includes changes
1. `src/components/Textarea/index.js`

### The Following Storybook file includes changes
1. `src/components/Textarea/Textarea.story.js `

# Updated CHANGELOG