### PR TITLE
feat (DialogNew) Add option to hide overlay in dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Feature] Add hasOverlay prop to DialogNew ([#1160](https://github.com/optimizely/oui/pull/1160)) 
 
 ## 42.8.3 - 2019-05-06
 - [Patch] Fix regression caused by react-popper upgrade ([#1158](https://github.com/optimizely/oui/pull/1158))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
-- [Feature] Add hasOverlay prop to DialogNew ([#1160](https://github.com/optimizely/oui/pull/1160)) 
+- [Feature] Add `hasOverlay` prop to **DialogNew** ([#1160](https://github.com/optimizely/oui/pull/1160)) 
 
 ## 42.8.3 - 2019-05-06
 - [Patch] Fix regression caused by react-popper upgrade ([#1158](https://github.com/optimizely/oui/pull/1158))

--- a/src/components/Dialog/Dialog.story.js
+++ b/src/components/Dialog/Dialog.story.js
@@ -64,6 +64,7 @@ stories
           title={ text('title', 'This is a  Dialog') }
           subtitle={ text('subtitle', 'This is an optional subtitle') }
           hasCloseButton={ boolean('hasCloseButton', true) }
+          hasOverlay={ boolean('hasOverlay', true) }
           onClose={ action('Dialog was closed') }
           footerButtonList={ [
             <Button style="plain" key={ 0 } onClick={ noop }>
@@ -97,6 +98,7 @@ stories
           title={ text('title', 'Welcome to this Feature') }
           subtitle={ <p>Let&apos;s get you up and running with <a href="https://www.optimizely.com/">our feature.</a></p> }
           hasCloseButton={ boolean('hasCloseButton', true) }
+          hasOverlay={ boolean('hasOverlay', true) }
           onClose={ action('Dialog was closed') }
           footerButtonList={ [
             <Button style="highlight" key={ 0 } onClick={ noop }>
@@ -129,6 +131,7 @@ stories
           title={ text('title', 'Welcome to this Feature') }
           hasCloseButton={ boolean('hasCloseButton', true) }
           onClose={ action('Dialog was closed') }
+          hasOverlay={ boolean('hasOverlay', true) }
           footerButtonList={ [
             <Button style="highlight" key={ 0 } onClick={ noop }>
               Get Started in the Docs
@@ -165,6 +168,29 @@ stories
         <DialogNew
           title={ text('title', 'This is a Dialog') }
           hasCloseButton={ boolean('hasCloseButton', false) }
+          hasOverlay={ boolean('hasOverlay', true) }
+          footerButtonList={ [
+            <Button style="plain" key={ 0 } onClick={ noop }>
+              No Thanks
+            </Button>,
+            <Button style="highlight" key={ 1 } onClick={ noop }>
+              Continue
+            </Button>,
+          ] }>
+          <p>Dialogs can also contain only text in the body, no data input.</p>
+          <p>They can also contain links, like <a href="https://www.optimizely.com/">learn more about Optimizely features</a>.</p>
+        </DialogNew>
+      </div>
+    ))
+  )
+  .add(
+    'without overlay', (() => (
+      <div>
+        <p>This is text behind the dialog that is NOT blocked by the overlay because the overlay is hidden.</p>
+        <DialogNew
+          title={ text('title', 'This is a Dialog') }
+          hasCloseButton={ boolean('hasCloseButton', false) }
+          hasOverlay={ boolean('hasOverlay', false) }
           footerButtonList={ [
             <Button style="plain" key={ 0 } onClick={ noop }>
               No Thanks

--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -16,7 +16,11 @@ export const DialogNew = props => {
   }
   return (
     <div className="oui-dialog__wrapper">
-      <div className="oui-dialog__overlay" />
+      {
+        props.hasOverlay && (
+          <div className="oui-dialog__overlay" />
+        )
+      }
       <div
         data-ui-component={ true }
         className="oui-dialog"
@@ -51,6 +55,11 @@ DialogNew.propTypes = {
    */
   hasCloseButton: PropTypes.bool,
   /**
+   * Used to determine if dialog should have a semi
+   * transparent overlay behind it.
+   */
+  hasOverlay: PropTypes.bool,
+  /**
    *  Function to perform when the dialog is closed.
    */
   onClose: PropTypes.func,
@@ -70,6 +79,7 @@ DialogNew.propTypes = {
 
 DialogNew.defaultProps = {
   hasCloseButton: true,
+  hasOverlay: true,
   onClose: () => {},
   subtitle: '',
   testSection: '',

--- a/src/components/Dialog/tests/index.js
+++ b/src/components/Dialog/tests/index.js
@@ -156,4 +156,51 @@ describe('Dialog Component ', () => {
     </DialogNew>);
     expect(component.find('.oui-close-button').length).toBe(0);
   });
+
+  it('renders the overlay behind the dialog', function() {
+    const onClickSpy = jest.fn();
+    const onCloseSpy = jest.fn();
+
+    const bodyString = 'Dialogs can contain simple text in the body.';
+
+    const component = mount(<DialogNew
+      title='This is a Dialog'
+      onClose={ onCloseSpy }
+      footerButtonList={ [
+        <Button style="plain" key={ 0 } onClick={ onClickSpy }>
+          No Thanks
+        </Button>,
+        <Button style="highlight" key={ 1 } onClick={ onClickSpy }>
+          Continue
+        </Button>,
+      ] }>
+      <p>{bodyString}</p>
+    </DialogNew>);
+
+    expect(component.find('.oui-dialog__overlay').length).toBe(1);
+  });
+
+  it('does not render the overlay behind the dialog if hasOverlay is false', function() {
+    const onClickSpy = jest.fn();
+    const onCloseSpy = jest.fn();
+
+    const bodyString = 'Dialogs can contain simple text in the body.';
+
+    const component = mount(<DialogNew
+      title='This is a Dialog'
+      onClose={ onCloseSpy }
+      hasOverlay={ false }
+      footerButtonList={ [
+        <Button style="plain" key={ 0 } onClick={ onClickSpy }>
+          No Thanks
+        </Button>,
+        <Button style="highlight" key={ 1 } onClick={ onClickSpy }>
+          Continue
+        </Button>,
+      ] }>
+      <p>{bodyString}</p>
+    </DialogNew>);
+
+    expect(component.find('.oui-dialog__overlay').length).toBe(0);
+  });
 });


### PR DESCRIPTION
This diff adds a prop to DialogNew to allow consumers to not add an overlay behind the dialog. This prop defaults to true, so the overlay is shown by default.