### PR TITLE
feat (TokensInput) Add more event handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 - [Feature] Add ability to provide **SelectDropdown** with an `initialPlaceholder` value to use when a value is not yet selected ([#1176](https://github.com/optimizely/oui/pull/1176))
     - Also changed the `value` prop to no longer be required
 - [Patch] Fix **Progress Dots** to prevent wrapping in narrow regions ([#1173](https://github.com/optimizely/oui/pull/1173))
+- [Feature] Add `onInputChange`, `onInputBlur`, and `onInputFocus` handlers to the **TokenInput** component.
 
 ## 43.0.0 - 2019-06-12
 - [Patch] Fix **TokensInput** `extraAddKeys` prop-type check

--- a/src/components/TokensInput/index.js
+++ b/src/components/TokensInput/index.js
@@ -185,7 +185,7 @@ TokensInput.propTypes = {
   onChange: PropTypes.func.isRequired,
 
   /**
-   * Handler to invoke when the token input is blured
+   * Handler to invoke when the token input is blurred
    */
   onInputBlur: PropTypes.func,
 

--- a/src/components/TokensInput/index.js
+++ b/src/components/TokensInput/index.js
@@ -42,6 +42,9 @@ export const TokensInput = ({
   extraAddKeys,
   maxTags,
   onChange,
+  onInputBlur,
+  onInputChange,
+  onInputFocus,
   placeholder,
   tokens,
 }) => {
@@ -141,6 +144,9 @@ export const TokensInput = ({
         addOnPaste={ true }
         inputProps={{
           className: `flex flex--1 ${minWidth} no-border soft-half--ends soft--sides`,
+          onBlur: onInputBlur,
+          onChange: onInputChange,
+          onFocus: onInputFocus,
           placeholder: isNumberOfTokensMoreThanOrEqualToMaxTags ? '' : placeholder,
           readOnly: isNumberOfTokensMoreThanOrEqualToMaxTags,
         }}
@@ -179,6 +185,21 @@ TokensInput.propTypes = {
   onChange: PropTypes.func.isRequired,
 
   /**
+   * Handler to invoke when the token input is blured
+   */
+  onInputBlur: PropTypes.func,
+
+  /**
+   * Handler to invoke when the token input changes
+   */
+  onInputChange: PropTypes.func,
+
+  /**
+   * Handler to invoke when the token input is focused
+   */
+  onInputFocus: PropTypes.func,
+
+  /**
    * Placeholder text for the input box.
    */
   placeholder: PropTypes.string,
@@ -194,6 +215,12 @@ TokensInput.defaultProps = {
   extraAddKeys: [],
 
   maxTags: -1,
+
+  onInputBlur: () => {},
+
+  onInputChange: () => {},
+
+  onInputFocus: () => {},
 
   placeholder: 'enter tokens',
 };

--- a/src/components/TokensInput/tests/index.js
+++ b/src/components/TokensInput/tests/index.js
@@ -15,6 +15,9 @@ const SAMPLE_DATA = [
 describe('components/TokensInput', () => {
   let component;
   let mockOnChange;
+  let mockOnInputBlur;
+  let mockOnInputChange;
+  let mockOnInputFocus;
 
   afterEach(function() {
     if (component) {
@@ -110,8 +113,17 @@ describe('components/TokensInput', () => {
     describe('with the default addKeys', function() {
       beforeEach(function() {
         mockOnChange = jest.fn();
+        mockOnInputBlur = jest.fn();
+        mockOnInputChange = jest.fn();
+        mockOnInputFocus = jest.fn();
         component = mount(
-          <TokensInput onChange={ mockOnChange } tokens={ SAMPLE_DATA } />
+          <TokensInput
+            onChange={ mockOnChange }
+            onInputBlur={ mockOnInputBlur }
+            onInputChange={ mockOnInputChange }
+            onInputFocus={ mockOnInputFocus }
+            tokens={ SAMPLE_DATA }
+          />
         );
       });
 
@@ -134,6 +146,25 @@ describe('components/TokensInput', () => {
 
         expect(mockOnChange).toBeCalled();
         expect(mockOnChange).toHaveBeenCalledWith(SAMPLE_DATA);
+      });
+
+      it('should call onInputChange when input is changed', function() {
+        const input = component.find('input');
+        input.simulate('change', { target: { value: 'primary' }});
+        component.update();
+        expect(mockOnInputChange).toBeCalled();
+      });
+
+      it('should call onInputFocus when input is focused', function() {
+        const input = component.find('input');
+        input.simulate('focus');
+        expect(mockOnInputFocus).toBeCalled();
+      });
+
+      it('should call onInputBlur when input is blur', function() {
+        const input = component.find('input');
+        input.simulate('blur');
+        expect(mockOnInputBlur).toBeCalled();
       });
     });
 
@@ -183,7 +214,7 @@ describe('components/TokensInput', () => {
         const input = component.find('input');
         /* eslint-disable no-tabs */
         const testString = `
-        
+
         some
         	tokens
         		with
@@ -191,7 +222,7 @@ describe('components/TokensInput', () => {
         	one.two
         	three,
         	four_five
-        	
+
         `;
         input.simulate('paste', { clipboardData: { getData: () => testString }});
         component.update();


### PR DESCRIPTION
## Summary

Add `onInputChange`, `onInputBlur`, and `onInputFocus` handlers to the TokenInput component.

## Test Plan

Ran the test suite `yarn test`