### PR TITLE
Textarea patch on numRows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Modification to `numRows` prop for **Textarea** component ([#1216](https://github.com/optimizely/oui/pull/1216))
 
 ## 44.6.0 - 2019-08-15
 - [Feature] Modifications/Improvements to the **EmptyDashboard** component ([#1211](https://github.com/optimizely/oui/pull/1211)):

--- a/src/components/Textarea/Textarea.story.js
+++ b/src/components/Textarea/Textarea.story.js
@@ -23,6 +23,7 @@ stories
           isDisabled={ boolean('isDisabled', false) }
           defaultValue='Delete this default value and see the placeholder'
           maxLength={ number('maxLength', 250) }
+          numRows={ number('numRows', 25) }
           placeholder={ text('placeHolder', 'Enter a comment') }
           onBlur={ action('Textarea: onBlur') }
           onChange={ action('Textarea: onChange') }

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -52,7 +52,7 @@ class Textarea extends React.Component {
         disabled={ isDisabled }
         { ...(typeof maxLength === 'undefined' ? {} : { maxLength }) }
         maxLength={ maxLength }
-        numRows={ numRows }
+        rows={ numRows }
         onInput={ onInput }
         onChange={ onChange }
         onBlur={ onBlur }

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -168,6 +168,7 @@ Textarea.defaultProps = {
   focus: false,
   label: null,
   note: null,
+  numRows: 3,
   isOptional: false,
 };
 

--- a/src/components/Textarea/index.scss
+++ b/src/components/Textarea/index.scss
@@ -33,7 +33,6 @@
 .oui-textarea {
   @include text-input;
 
-  height: 62px;
   resize: vertical;
 
   &--tall {

--- a/src/components/Textarea/tests/index.js
+++ b/src/components/Textarea/tests/index.js
@@ -155,7 +155,7 @@ describe('components/Textarea', () => {
     const component = mount(
       <Textarea numRows={ 10 } />
     );
-    expect(component.find('textarea').prop('numRows')).toBe(10);
+    expect(component.find('textarea').prop('rows')).toBe(10);
   });
 
   it('should add a maxLength attribute when maxLength is passed', () => {


### PR DESCRIPTION
- Account for `textarea` expecting the prop to be called `rows` even though the OUI component calls it `numRows`
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea 
- Remove height specification in the CSS so that `rows` can kick in
- Add to storybook