### PR TITLE
patch(Poptip): Prevent Poptip to display "undefined" on hover when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [patch] Prevent Poptip to show "undefined" hover message when it gets disabled ([#1218](https://github.com/optimizely/oui/pull/1218))
 
 ## 44.7.0 - 2019-08-23
 - [Feature] Added **NavBar** component ([#1212](https://github.com/optimizely/oui/pull/1212))

--- a/src/components/Poptip/index.js
+++ b/src/components/Poptip/index.js
@@ -102,7 +102,7 @@ class Poptip extends React.Component {
         position={ position }
         theme={ theme }
         trigger={ trigger }>
-        <div className={ wrapperInline }>{ children }</div>
+        <div className={ wrapperInline } title="">{ children }</div>
       </Tooltip>
     );
   };


### PR DESCRIPTION
# Summary:

Added title prop in the child div of `Tooltip`. This prevents the "undefined" message that appears when we disable and hover over it.

This bug was identified in this [PR](https://github.com/optimizely/optimizely/pull/10745)

# Test Plan:
All tests are working
