### PR TITLE
security bump for lodash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Yarn upgrades for GitHub security alerts ([#1224](https://github.com/optimizely/oui/pull/1224))
 
 ## 44.9.0 - 2019-09-30
 - [Feature] Add time inputs to the **DateRangePicker** component ([#1221](https://github.com/optimizely/oui/pull/1221)):
     - Added time inputs as an option
     - Added custom time-handling for a delightful experience
-- [Patch] Yarn upgrades for GitHub security alerts ([#1222](https://github.com/optimizely/oui/pull/1190))
+- [Patch] Yarn upgrades for GitHub security alerts ([#1222](https://github.com/optimizely/oui/pull/1222))
 
 ## 44.8.0 - 2019-09-11
 - [Feature] New **PaginationControls** component ([#1190](https://github.com/optimizely/oui/pull/1190))

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "handlebars": "^4.0.14",
     "highlight.js": "9.5.0",
     "immutable": "3.x.x",
-    "lodash": "4.x.x",
+    "lodash": ">=4.17.13",
     "lodash-es": "^4.17.14",
     "lodash.debounce": "^4.0.8",
     "lodash.noop": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,7 +2445,7 @@ async@^1.4.0, async@^1.5.2:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.1.2, async@^2.1.4, async@^2.4.1, async@^2.5.0:
+async@^2.1.2, async@^2.1.4, async@^2.4.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
   integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
@@ -8406,6 +8406,11 @@ lodash.words@^3.0.0:
   integrity sha1-TiqGSbwIdFsXxpWxo86P7llmI7M=
   dependencies:
     lodash._root "^3.0.0"
+
+lodash@4.17.13:
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
+  integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
 
 lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.15"


### PR DESCRIPTION
1. Bump for lodash
1. Also includes running `yarn-deduplicate yarn.lock`

<img width="767" alt="Screen Shot 2019-10-03 at 10 49 34 AM 1" src="https://user-images.githubusercontent.com/16581943/66151118-82609400-e5cb-11e9-8755-da4f200b52e0.png">
