### PR TITLE
fix (Security) Update lodash to resolve security issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "handlebars": "^4.0.14",
     "highlight.js": "9.5.0",
     "immutable": "3.x.x",
-    "lodash": "4.x.x",
+    "lodash": ">=4.17.13",
     "lodash-es": "^4.17.14",
     "lodash.debounce": "^4.0.8",
     "lodash.noop": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,7 +2445,7 @@ async@^1.4.0, async@^1.5.2:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.1.2, async@^2.1.4, async@^2.4.1, async@^2.5.0:
+async@^2.1.2, async@^2.1.4, async@^2.4.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
   integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
@@ -8407,7 +8407,7 @@ lodash.words@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
+lodash@4.x.x, lodash@>=4.17.13, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
OUI has a security warning issued:
![image](https://user-images.githubusercontent.com/2287470/66498055-73765780-ea8b-11e9-8fb3-a8df247663ca.png)

This diff specifies that lodash cannot be set to lower than the known good version. We had the known good version specified in our checked in yarn.lock so this is not too worrisome, but this will prevent any backslip.