### PR TITLE
fix (Dropdown) Use proper value for maxHeight style in Dropdown.Contents

### DIFF
--- a/src/components/Dropdown/DropdownContents/index.js
+++ b/src/components/Dropdown/DropdownContents/index.js
@@ -10,7 +10,7 @@ export default function DropdownContents(props) {
 
   if (props.canScroll) {
     styleProps.overflowY = 'visible';
-    styleProps.maxHeight = 'auto';
+    styleProps.maxHeight = 'none';
   }
 
   const classes = classNames({

--- a/src/components/Dropdown/DropdownContents/tests/index.js
+++ b/src/components/Dropdown/DropdownContents/tests/index.js
@@ -45,6 +45,6 @@ describe('components/Dropdown/DropdownContents', () => {
 
   it('should render with scroll styles if canScroll', () => {
     const component = shallow(<DropdownContents canScroll={ true }></DropdownContents>);
-    expect(component.find('ul').prop('style')).toEqual({ overflowY: 'visible', maxHeight: 'auto' });
+    expect(component.find('ul').prop('style')).toEqual({ overflowY: 'visible', maxHeight: 'none' });
   });
 });


### PR DESCRIPTION
Dropdown.Contents has a prop canScroll (which actually is implemented backwards, it would be more correct to call it cannotScroll), which forces the contents to not scroll when true. One part of this is to override the max height css property of oui-dropdown. This was previously implemented with maxHeight=auto, which is not a valid value for max height, so it wasn't being applied as a style.
 
![image (4)](https://user-images.githubusercontent.com/2287470/66507718-b9d4b200-ea9d-11e9-9324-cbd1b2c5100c.png)

This popped up as an issue in this UI, visible when the hover state was misaligned with the dropdown:
![image](https://user-images.githubusercontent.com/2287470/66507840-f1dbf500-ea9d-11e9-85f2-96294d92f883.png)
