### PR TITLE
feat (SelectDropdown) Add support for full width activator in SelectDropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 - [Feature] New **DockedFooter** sticky-to-the-bottom button row component ([#1247](https://github.com/optimizely/oui/pull/1247))
 - [Feature] Improve keyboard accessibility by updating **HelpPopover** to use ButtonIcon component and be a focusable element ([#1254](https://github.com/optimizely/oui/pull/1254))
 - Add ability to associate a **ButtonIcon** with another component, like a **Popover**, using `ariaDescribedBy` and `popoverId` props
+- [Patch] Upate `<SelectDropdown>` to accept a `fullWidth` prop. ([#1256](https://github.com/optimizely/oui/pull/1258))
 
 ## 44.11.0 - 2019-11-06
 

--- a/src/components/SelectDropdown/SelectDropdown.story.js
+++ b/src/components/SelectDropdown/SelectDropdown.story.js
@@ -74,6 +74,19 @@ stories.add('Default', (() => {
       />
     </Container>
   );
+})).add('Full Width Activator', (() => {
+  return (
+    <Container>
+      <div style={{'width': '400px', 'border': '1px solid', 'height': '100px' }}>
+        <SelectDropdown
+          items={ items }
+          value={ 'dog' }
+          onChange={ action('SelectDropdown value changed') }
+          fullWidth={ true }
+        />
+      </div>
+    </Container>
+  );
 })).add('Specify max width of activator', (() => {
   return (
     <div>

--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -20,6 +20,10 @@ class SelectDropdown extends React.Component {
      */
     dropdownDirection: PropTypes.oneOf(['right', 'left']),
     /**
+     * Should activator be full width of container
+     */
+    fullWidth: PropTypes.bool,
+    /**
      * An initial value for the dropdown before anything is selected
      */
     initialPlaceholder: PropTypes.node,
@@ -93,6 +97,7 @@ class SelectDropdown extends React.Component {
     initialPlaceholder: '',
     displayError: false,
     dropdownDirection: 'right',
+    fullWidth: false,
     width: '100%',
     trackId: '',
     testSection: '',
@@ -169,12 +174,13 @@ class SelectDropdown extends React.Component {
   };
 
   render() {
-    const { isDisabled, zIndex } = this.props;
+    const { isDisabled, zIndex, fullWidth } = this.props;
 
     return (
       <Dropdown
         { ...(zIndex ? { zIndex } : {}) }
         isDisabled={ isDisabled }
+        fullWidth={ fullWidth }
         renderActivator={ this.renderActivator }>
         { this.renderContents() }
       </Dropdown>

--- a/src/components/SelectDropdown/tests/index.js
+++ b/src/components/SelectDropdown/tests/index.js
@@ -66,6 +66,17 @@ describe('components/SelectDropdown', function() {
     });
   });
 
+  it('should pass fullWidth prop to Dropdown', function() {
+    component = mount(
+      <SelectDropdown
+        items={ items }
+        value={ 'value 2' }
+        onChange={ onChange }
+        fullWidth={ true }
+      />);
+    expect(component.find('Dropdown').prop('fullWidth')).toEqual(true);
+  });
+
   it('should set the maxWidth of the activator', function() {
     component = mount(
       <SelectDropdown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2320,7 +2320,7 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-array.prototype.find@^2.0.4, array.prototype.find@^2.1.0:
+array.prototype.find@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.1.0.tgz#630f2eaf70a39e608ac3573e45cf8ccd0ede9ad7"
   integrity sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==
@@ -5179,7 +5179,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.10.0, es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.15.0, es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.7.0, es-abstract@^1.9.0:
+es-abstract@^1.10.0, es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.15.0, es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.7.0, es-abstract@^1.9.0:
   version "1.16.2"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.2.tgz#4e874331645e9925edef141e74fc4bd144669d34"
   integrity sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==
@@ -5195,7 +5195,7 @@ es-abstract@^1.10.0, es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.13
     string.prototype.trimleft "^2.1.0"
     string.prototype.trimright "^2.1.0"
 
-es-to-primitive@^1.2.0, es-to-primitive@^1.2.1:
+es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
   integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
@@ -7186,7 +7186,7 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
-is-callable@^1.1.3, is-callable@^1.1.4:
+is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
   integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
@@ -10877,7 +10877,7 @@ react-inspector@^3.0.2:
     is-dom "^1.0.9"
     prop-types "^15.6.1"
 
-react-is@^16.10.2, react-is@^16.5.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.10.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
@@ -11789,13 +11789,6 @@ sax@>=0.6.0, sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-
-schedule@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.5.0.tgz#c128fffa0b402488b08b55ae74bb9df55cc29cc8"
-  integrity sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==
-  dependencies:
-    object-assign "^4.1.1"
 
 scheduler@^0.17.0:
   version "0.17.0"


### PR DESCRIPTION
Summary:
I am currently working on a table where one of the cells is a SelectDropdown instance. Currently it's not possible to configure the SelectDropdown activator to take up the full width of the table cell:
![image](https://user-images.githubusercontent.com/2287470/69758002-6d683300-112c-11ea-9e53-55446f1b420b.png)

This diff adds a prop to SelectDropdown, `fullWidth`, which is passed along to Dropdown. This does add to the already existing confusion of width props on SelectDropdown. However I considered trying to leverage the existing width property, like setting `fullWidth=true` on Dropdown if SelectDropdown.props.width=100%. I decided against this because the default value for SelectDropdown.props.width is 100%, so this could cause unexpected ripple effects in the app. I'm definitely open to suggestions of how to solve this other than adding another width prop!
 