### PR TITLE
fix (Dropdown) Reset dropdown activator to past state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Undo parent prop inheritance on Activator in **Dropdown** ([#1262])(https://github.com/optimizely/oui/pull/1262)
 
 ## 44.13.4 - 2019-12-06
 - [Patch] Align **SelectDropdown** activator text to the left ([#1260])(https://github.com/optimizely/oui/pull/1260)

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -136,10 +136,8 @@ class Dropdown extends React.Component {
                 // To be deprecated in favor of renderActivator
                 return React.cloneElement(this.props.activator, {
                   buttonRef: ref,
-                  disabled: isDisabled,
                   onBlur: this.handleOnBlur,
                   onClick: this.handleToggle,
-                  testSection: testSection,
                 });
               }
             }}


### PR DESCRIPTION
[Recent changes to the Dropdown component](https://github.com/optimizely/oui/commit/1d65c8dcca3b18c7d4ec0987869b8c5796cb3e57#diff-cfb31a497acad7b25b60969ed6cb9ce2R142) had the activator inherit the test section and disabled props from the parent, while existing implementations set the test section and disabled props on the activator component itself. These changes caused many tests to break. This diff undoes the changes to the Dropdown to be compatible with our existing implementations.