### PR TITLE
fix (Dropdown) Reset dropdown back to previous state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 
 ## Unreleased
 - [Release] Remove deprecated CodeDiffLegacy component in favor of CodeDiff ([#1277](https://github.com/optimizely/oui/pull/1277))
+- [Patch] Undo parent prop inheritance on Activator in **Dropdown** ([#1278](https://github.com/optimizely/oui/pull/1278))
 
 ## 44.18.0 - 2020-01-16
 - [Feature] Adding a `SearchPicker` component ([#1253](https://github.com/optimizely/oui/pull/1253)))

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -162,10 +162,8 @@ class Dropdown extends React.Component {
                 return React.cloneElement(this.props.activator, {
                   buttonRef: ref,
                   ref,
-                  disabled: isDisabled,
                   onBlur: this.handleOnBlur,
                   onClick: this.handleToggle,
-                  testSection: testSection,
                 });
               }
             }}


### PR DESCRIPTION
Dropdown was erroneously updated in [this PR](https://github.com/optimizely/oui/pull/1253/files?file-filters%5B%5D=.html&file-filters%5B%5D=.js&file-filters%5B%5D=.json#diff-cfb31a497acad7b25b60969ed6cb9ce2R165) This diff removes these updates to enable Dropdown to work correctly in monolith tests again