### PR TITLE
fix (SearchPicker) Wait for all queries to complete before showing result summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 
 ## Unreleased
 - [Patch] Update `isReadingColumn` prop on **Col** component to create a nested reading column ([#1285](https://github.com/optimizely/oui/pull/1285))
+- [Patch] Wait for all queries to be complete before showing result summary in **SearchPicker** ([#1284](https://github.com/optimizely/oui/pull/1284))
+- [Patch] Allow for an offset in **SearchPicker** children ([#1281](https://github.com/optimizely/oui/pull/1281))
 
 ## 45.1.0 - 2020-01-24
 - [Feature] Add new **DragAndDrop** component using react-beautiful-dnd that allows for dynamic lists, interactive elements inside the draggable items, and keyboard accessibility ([#1261](https://github.com/optimizely/oui/pull/1261))

--- a/src/components/SearchPicker/index.js
+++ b/src/components/SearchPicker/index.js
@@ -200,9 +200,6 @@ class SearchPicker extends React.Component {
         query: query.toLowerCase(),
       })
         .then(resolve, reject);
-    }).then(r => r, e => { 
-      // Pass rejections to executeNewSearch error handler
-      throw new Error(e)
     });
 
   /**
@@ -215,10 +212,14 @@ class SearchPicker extends React.Component {
       this.setState({
         isLoading: false,
         currentSearch: null,
-        // Ensure the query wasn't killed while waiting for the result.
-        ...(searchQuery ? { results: results } : {})
       });
-    }, e => { /* Swallow errors */ });
+      // Ensure the query wasn't killed while waiting for the result.
+      if (searchQuery) {
+        this.setState({
+          results,
+        });
+      }
+    }, e => { /** Swallow rejections */});
   }, !!process.env.JEST_WORKER_ID ? 0 : INPUT_DEBOUNCE_PERIOD);
 
   /**
@@ -246,10 +247,11 @@ class SearchPicker extends React.Component {
    */
   getResultsText = () => {
     const { supportedTypes } = this.props;
-    const { isLoading, searchQuery, results } = this.state;
+    const { isLoading, searchQuery } = this.state;
     const resultCount = this.getResultSet().length;
     const summaryNoun = supportedTypes.length > 1 ? 'entities' : `${supportedTypes[0]}s`;
     let summary = `Recently created ${summaryNoun}`;
+
     if (isLoading) {
       summary = `Searching for "${summaryNoun}" matching "${searchQuery}"`;
     } else if (searchQuery) {

--- a/src/components/SearchPicker/tests/index.js
+++ b/src/components/SearchPicker/tests/index.js
@@ -7,7 +7,7 @@ import MOCK_DATA from '../mock_api/mock_data';
 
 import SearchPicker from '../';
 
-const MOCK_API_DELAY = 10;
+const MOCK_API_DELAY = 100;
 
 const searchFunction = getSearchFunction(MOCK_API_DELAY);
 
@@ -96,8 +96,7 @@ describe('components/SearchPicker', () => {
     it('should wait to show results until all queries are completed', function() {
       expect(renderedData.isLoading).toBe(true);
       return getDelayedPromise(MOCK_API_DELAY).then(() => {
-        expect(renderedData.searchQuery).toBe('');
-        expect(renderedData.isLoading).toBe(false);
+        expect(renderedData.resultsText).toEqual({summary: 'Recently created features'});
         component.find('input').simulate('mouseenter');
         component.find('input').simulate('click');
         component.find('input').simulate('input', { target: { value: '123' }});
@@ -113,6 +112,11 @@ describe('components/SearchPicker', () => {
           component.find('input').simulate('click');
           component.find('input').simulate('input', { target: { value: '202' }});
         })
+        .then(() => getDelayedPromise(MOCK_API_DELAY))
+        .then(() => {
+          component.update();
+          expect(renderedData.resultsText).toEqual({summary: 'Searching for "features" matching "202"'});
+        })
         // Account for our mock API delay and the debounce delay
         .then(() => getDelayedPromise(MOCK_API_DELAY + 10))
         .then(() => {
@@ -120,7 +124,6 @@ describe('components/SearchPicker', () => {
           expect(renderedData.isLoading).toBe(false);
           expect(renderedData.resultsText).toEqual({summary: 'Found 1 features matching "202"'});
         });
-
     })
   });
 });

--- a/src/components/SearchPicker/tests/index.js
+++ b/src/components/SearchPicker/tests/index.js
@@ -106,7 +106,7 @@ describe('components/SearchPicker', () => {
         .then(() => {
           expect(renderedData.searchQuery).toBe('123');
           expect(renderedData.isLoading).toBe(true);
-          component.update()
+          component.update();
           expect(renderedData.resultsText).toEqual({summary: 'Searching for "features" matching "123"'});
           component.find('input').simulate('mouseenter');
           component.find('input').simulate('click');
@@ -124,6 +124,6 @@ describe('components/SearchPicker', () => {
           expect(renderedData.isLoading).toBe(false);
           expect(renderedData.resultsText).toEqual({summary: 'Found 1 features matching "202"'});
         });
-    })
+    });
   });
 });


### PR DESCRIPTION
This resolves the issue as seen in this GIF:
![search-picker-4](https://user-images.githubusercontent.com/2287470/73200445-ca6c6f00-4104-11ea-832f-8c30e83414bd.gif)
The summary was being incorrectly populated because of how we were handling the promise then/catch scenarios