### PR TITLE
feat(SelectDropdown): Add optional link to the select dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Add `linkURL` and `linkText` to items on **SelectDropdown** component to allow optional links ([#1286](https://github.com/optimizely/oui/pull/1286))
 
 ## 45.2.0 - 2020-01-28
 - [Patch] Update `isReadingColumn` prop on **Col** component to create a nested reading column ([#1285](https://github.com/optimizely/oui/pull/1285))

--- a/src/components/SelectDropdown/SelectDropdown.story.js
+++ b/src/components/SelectDropdown/SelectDropdown.story.js
@@ -184,7 +184,7 @@ stories.add('Default', (() => {
   return (
     <Container>
       <SelectDropdown
-        items={ [{label: 'Elephant', description: 'Very loud', value: 'elephant', linkText: 'I am a link, click me!', linkURL: 'https://www.google.com'}].concat(items) }
+        items={ [{label: 'Elephant', description: 'Very loud', value: 'elephant', linkText: 'I am a link, click me!', linkURL: 'https://www.google.com', linkNewWindow: true}].concat(items) }
         initialPlaceholder="Select a value..."
         onChange={ action('SelectDropdown value changed') }
       />

--- a/src/components/SelectDropdown/SelectDropdown.story.js
+++ b/src/components/SelectDropdown/SelectDropdown.story.js
@@ -180,6 +180,16 @@ stories.add('Default', (() => {
       />
     </Container>
   );
+})).add('Items with linkText or linkURL', (() => {
+  return (
+    <Container>
+      <SelectDropdown
+        items={ [{label: 'Elephant', description: 'Very loud', value: 'elephant', linkText: 'I am a link, click me!', linkURL: 'https://www.google.com'}].concat(items) }
+        initialPlaceholder="Select a value..."
+        onChange={ action('SelectDropdown value changed') }
+      />
+    </Container>
+  );
 }));
 
 const Container = styled.div`

--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -157,6 +157,10 @@ class SelectDropdown extends React.Component {
     );
   };
 
+  handleLinkClick = (e) => {
+    e.stopPropagation();
+  };
+
   renderContents = () => {
     const { isMultiSelect, items, onChange, value, minDropdownWidth, dropdownDirection } = this.props;
 
@@ -182,7 +186,7 @@ class SelectDropdown extends React.Component {
               <div className="micro muted">
                 <Link
                   title={ entry.linkText }
-                  onClick={ (e) => e.stopPropagation() }
+                  onClick={ this.handleLinkClick }
                   newWindow={ true }
                   href={ entry.linkURL }>
                   { entry.linkText}

--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -180,10 +180,11 @@ class SelectDropdown extends React.Component {
             </Dropdown.BlockLink>
             { entry.linkText && entry.linkURL && (
               <div className="micro muted">
-                <Link title={ entry.linkText }
-                      onClick={ (e) => e.stopPropagation() }
-                      newWindow={true}
-                      href={entry.linkURL}>
+                <Link
+                  title={ entry.linkText }
+                  onClick={ (e) => e.stopPropagation() }
+                  newWindow={ true }
+                  href={ entry.linkURL }>
                   { entry.linkText}
                 </Link>
               </div>

--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -50,6 +50,7 @@ class SelectDropdown extends React.Component {
         PropTypes.number,
         PropTypes.bool,
       ]).isRequired,
+      linkNewWindow: PropTypes.bool,
       linkText: PropTypes.string,
       linkURL: PropTypes.string,
     })).isRequired,
@@ -187,7 +188,7 @@ class SelectDropdown extends React.Component {
                 <Link
                   title={ entry.linkText }
                   onClick={ this.handleLinkClick }
-                  newWindow={ true }
+                  newWindow={ entry.linkNewWindow }
                   href={ entry.linkURL }>
                   { entry.linkText}
                 </Link>

--- a/src/components/SelectDropdown/index.js
+++ b/src/components/SelectDropdown/index.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 import Button from '../Button';
 import Dropdown from '../Dropdown';
+import Link from '../Link';
 
 class SelectDropdown extends React.Component {
   static propTypes = {
@@ -49,6 +50,8 @@ class SelectDropdown extends React.Component {
         PropTypes.number,
         PropTypes.bool,
       ]).isRequired,
+      linkText: PropTypes.string,
+      linkURL: PropTypes.string,
     })).isRequired,
     /**
      * Max width of the activator container.
@@ -175,6 +178,16 @@ class SelectDropdown extends React.Component {
                 </div>
               )}
             </Dropdown.BlockLink>
+            { entry.linkText && entry.linkURL && (
+              <div className="micro muted">
+                <Link title={ entry.linkText }
+                      onClick={ (e) => e.stopPropagation() }
+                      newWindow={true}
+                      href={entry.linkURL}>
+                  { entry.linkText}
+                </Link>
+              </div>
+            )}
           </Dropdown.ListItem>
         ))}
       </Dropdown.Contents>

--- a/src/components/SelectDropdown/tests/index.js
+++ b/src/components/SelectDropdown/tests/index.js
@@ -204,4 +204,63 @@ describe('components/SelectDropdown', function() {
     expect(component.find('Checkbox').length).toBe(2);
     expect(component.find('Checkbox').last().prop('defaultChecked')).toBe(true);
   });
+  describe('links', function() {
+    describe('if linkURL and linkText are provided', function() {
+      beforeEach(function() {
+        component = mount(
+          <SelectDropdown
+            isMultiSelect={ true }
+            items={ [{label: 'label0', value: 'value0', description: 'description0', linkURL: '#', linkText: 'some link'}].concat(items) }
+            initialPlaceholder="Select a value..."
+            onChange={ onChange }
+          />);
+        const activator = component.find('Button');
+        activator.simulate('click');
+      });
+
+      it('should display text and link', function() {
+        expect(component.find('DropdownListItem').at(0).find('Link').length).toBe(1);
+        expect(component.find('DropdownListItem').at(0).find('Link').text()).toBe('some link');
+        expect(component.find('DropdownListItem').at(0).find('Link').props().href).toBe('#');
+      });
+
+      it('should not close the dropdown if clicked', function() {
+        const link = component.find('DropdownListItem').at(0).find('Link');
+        link.simulate('click'); // clicking on the link shouldn't close the dropdown
+        // this signals that the dropdown contents box doesn't close even when the link is clicked on
+        const dropdownContents = component.find('DropdownContents');
+        expect(dropdownContents.length).toBe(1);
+      });
+    });
+
+    describe('if linkURL is not provided', function() {
+      it('should not display text and link', function() {
+        component = mount(
+          <SelectDropdown
+            isMultiSelect={ true }
+            items={ [{label: 'label0', value: 'value0', description: 'description0', linkURL: '#'}].concat(items) }
+            initialPlaceholder="Select a value..."
+            onChange={ onChange }
+          />);
+        const activator = component.find('Button');
+        activator.simulate('click');
+        expect(component.find('DropdownListItem').at(0).find('Link').length).toBe(0);
+      });
+    });
+
+    describe('if linkText is not provided', function() {
+      it('should not display text and link', function() {
+        component = mount(
+          <SelectDropdown
+            isMultiSelect={ true }
+            items={ [{label: 'label0', value: 'value0', description: 'description0', linkText: 'some link'}].concat(items) }
+            initialPlaceholder="Select a value..."
+            onChange={ onChange }
+          />);
+        const activator = component.find('Button');
+        activator.simulate('click');
+        expect(component.find('DropdownListItem').at(0).find('Link').length).toBe(0);
+      });
+    });
+  });
 });

--- a/src/components/SelectDropdown/tests/index.js
+++ b/src/components/SelectDropdown/tests/index.js
@@ -210,7 +210,13 @@ describe('components/SelectDropdown', function() {
         component = mount(
           <SelectDropdown
             isMultiSelect={ true }
-            items={ [{label: 'label0', value: 'value0', description: 'description0', linkURL: '#', linkText: 'some link'}].concat(items) }
+            items={ [{
+              label: 'label0',
+              value: 'value0',
+              description: 'description0',
+              linkURL: '#',
+              linkText: 'some link',
+            }].concat(items) }
             initialPlaceholder="Select a value..."
             onChange={ onChange }
           />);
@@ -227,7 +233,7 @@ describe('components/SelectDropdown', function() {
       it('should not close the dropdown if clicked', function() {
         const link = component.find('DropdownListItem').at(0).find('Link');
         link.simulate('click'); // clicking on the link shouldn't close the dropdown
-        // this signals that the dropdown contents box doesn't close even when the link is clicked on
+        // check that the dropdown contents box doesn't close on link click
         const dropdownContents = component.find('DropdownContents');
         expect(dropdownContents.length).toBe(1);
       });
@@ -237,7 +243,12 @@ describe('components/SelectDropdown', function() {
       it('should not display text and link', function() {
         component = mount(
           <SelectDropdown
-            items={ [{label: 'label0', value: 'value0', description: 'description0', linkURL: '#'}].concat(items) }
+            items={ [{
+              label: 'label0',
+              value: 'value0',
+              description: 'description0',
+              linkURL: '#',
+            }].concat(items) }
             initialPlaceholder="Select a value..."
             onChange={ onChange }
           />);
@@ -251,7 +262,12 @@ describe('components/SelectDropdown', function() {
       it('should not display text and link', function() {
         component = mount(
           <SelectDropdown
-            items={ [{label: 'label0', value: 'value0', description: 'description0', linkText: 'some link'}].concat(items) }
+            items={ [{
+              label: 'label0',
+              value: 'value0',
+              description: 'description0',
+              linkText: 'some link',
+            }].concat(items) }
             initialPlaceholder="Select a value..."
             onChange={ onChange }
           />);

--- a/src/components/SelectDropdown/tests/index.js
+++ b/src/components/SelectDropdown/tests/index.js
@@ -237,7 +237,6 @@ describe('components/SelectDropdown', function() {
       it('should not display text and link', function() {
         component = mount(
           <SelectDropdown
-            isMultiSelect={ true }
             items={ [{label: 'label0', value: 'value0', description: 'description0', linkURL: '#'}].concat(items) }
             initialPlaceholder="Select a value..."
             onChange={ onChange }
@@ -252,7 +251,6 @@ describe('components/SelectDropdown', function() {
       it('should not display text and link', function() {
         component = mount(
           <SelectDropdown
-            isMultiSelect={ true }
             items={ [{label: 'label0', value: 'value0', description: 'description0', linkText: 'some link'}].concat(items) }
             initialPlaceholder="Select a value..."
             onChange={ onChange }


### PR DESCRIPTION
* Add optional linkURL and linkText props to SelectDropdown items. 
* When both are present, render a Link that opens in a new window when clicked.
* When the link is clicked, it should not close the SelectDropdown. 

Context: For the Edge project, we need to show an additional link under each item in the SelectDropdown, like so:

![image](https://user-images.githubusercontent.com/729524/73312109-d1ff4700-41dc-11ea-92f4-996acb111982.png)

Jira: https://optimizely.atlassian.net/browse/CJS-3830 