### PR TITLE
fix: Releasing OUI to NPM is failing, try setting `edge: true`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_deploy:
 - PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
 deploy:
 - provider: npm
+  edge: true
   skip_cleanup: true
   api_key:
     secure: ZP5NyAOstUcvmQEaAjJ9TRr+7GqiuK3iKBScADkVgetVhgBRaRy0O5x1OrRyy2i2p9Z2NnzIXe4jjDqueZ4lrpmBWgkfSFdVn1zYTgmc5g8yMP5HUIPHhQMj2DZ81VXCWLS2cdPyYspcIm1nFtzXQn6T0H8lH0hzWebXP2/cHrI=


### PR DESCRIPTION
Seems like something related to travis-ci's migration from v1 to v2 of their deployment tooling is causing releases of OUI to fail. 

See: https://travis-ci.community/t/missing-api-key-when-deploying-to-github-releases/5761/14
> This is indeed an incompatibility of the feature Build Config Validation with the beta version v2 of our deployment tooling dpl which is not used by default, yet. Build Config Validation applies a formal schema to your build configuration that specifies things as required for dpl v2, but not dpl v1 even though this is still the standard version (if everything goes to plan this default will be switched in Jan). This is an oversight on our part in coordinating these two non-trivial releases.

It seems the fix is to opt into `v2` of the deployment tooling `dpl` by setting `edge: true`. 

I've already tried opting out of the beta by clicking
![image](https://user-images.githubusercontent.com/729524/74889636-83a21b80-5336-11ea-928f-d3f3b3631a3d.png) but it seems to have no effect. 
