### PR TITLE
Add disabled to both stories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Add disabled example to **Input** and **Dropdown** stories ([#]())
 
 ## 45.8.0 - 2020-04-10
 - [Feature] Add ability to pass a node or string for the `linkLabel` in **NavBar** ([#1315](https://github.com/optimizely/oui/pull/1315))

--- a/src/components/Dropdown/Dropdown.story.js
+++ b/src/components/Dropdown/Dropdown.story.js
@@ -45,6 +45,7 @@ stories.add('Default', () => {
       <Dropdown
         buttonContent={ text('buttonContent', 'Default Dropdown') }
         width={ number('width', 300) }
+        isDisabled={ boolean('isDisabled', false) }
         arrowIcon={ select('arrowIcon', { up: 'up', down: 'down', left: 'left', right: 'right', none: 'none' }, 'down') }>
         <Dropdown.Contents>
           {data.map((item, index) => {

--- a/src/components/Input/Input.story.js
+++ b/src/components/Input/Input.story.js
@@ -92,6 +92,14 @@ stories
         <fieldset>
           <Input
             id="input-07"
+            placeholder="This input is disabled"
+            type="text"
+            isDisabled={ true }
+          />
+        </fieldset>
+        <fieldset>
+          <Input
+            id="input-08"
             type="time"
           />
         </fieldset>


### PR DESCRIPTION
This PR adds a disabled example for these stories
- Input
- Dropdown

One thing I noticed is Dropdown doesn't seem to disable the button, so something we should look into here or in another PR.