### PR TITLE
patch (Input) Add spellCheck prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+  - [Patch] Add `hasSpellCheck` prop to **Input** component ([#1338](https://github.com/optimizely/oui/pull/1338))
 
 ## 46.4.2 - 2020-06-08
 - [Patch] Allow **Disclose** to take a node or a string for `title` with `flex` ([#1354](https://github.com/optimizely/oui/pull/1354))
 - [Patch] Define missing components for typescript declarations ([#1352](https://github.com/optimizely/oui/pull/1352))
-- [Patch] Add `hasSpellCheck` prop to **Input** component ([#1338](https://github.com/optimizely/oui/pull/1338))
 
 ## 46.4.1 - 2020-05-29
 - [Patch] Update **Col** and **Ref** to accept ref props ([#1343](https://github.com/optimizely/oui/pull/1343))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 ## 46.4.2 - 2020-06-08
 - [Patch] Allow **Disclose** to take a node or a string for `title` with `flex` ([#1354](https://github.com/optimizely/oui/pull/1354))
 - [Patch] Define missing components for typescript declarations ([#1352](https://github.com/optimizely/oui/pull/1352))
+- [Patch] Add `hasSpellCheck` prop to **Input** component ([#1338](https://github.com/optimizely/oui/pull/1338))
 
 ## 46.4.1 - 2020-05-29
 - [Patch] Update **Col** and **Ref** to accept ref props ([#1343](https://github.com/optimizely/oui/pull/1343))
@@ -24,7 +25,6 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 - [Patch] Update **Token** and **Sortable** to always use hamburger drag handle by default ([#1337](https://github.com/optimizely/oui/pull/1337))
 - [Patch] Update react-oui-icons version to 2.9.0 ([#1336](https://github.com/optimizely/oui/pull/1336))
     - Update `icons.json` to use latest set of icons from v2.9.0
-- [Patch] Add `hasSpellCheck` prop to **Input** component ([#1338](https://github.com/optimizely/oui/pull/1338))
 
 ## 46.3.1 - 2020-05-19
 - [Patch] Export **ManagerSideNav** info for TypeScript ([#1334](https://github.com/optimizely/oui/pull/1334))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 - [Patch] Update **Token** and **Sortable** to always use hamburger drag handle by default ([#1337](https://github.com/optimizely/oui/pull/1337))
 - [Patch] Update react-oui-icons version to 2.9.0 ([#1336](https://github.com/optimizely/oui/pull/1336))
     - Update `icons.json` to use latest set of icons from v2.9.0
+- [Patch] Add `spellCheck` prop to **Input** component
 
 ## 46.3.1 - 2020-05-19
 - [Patch] Export **ManagerSideNav** info for TypeScript ([#1334](https://github.com/optimizely/oui/pull/1334))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 - [Patch] Update **Token** and **Sortable** to always use hamburger drag handle by default ([#1337](https://github.com/optimizely/oui/pull/1337))
 - [Patch] Update react-oui-icons version to 2.9.0 ([#1336](https://github.com/optimizely/oui/pull/1336))
     - Update `icons.json` to use latest set of icons from v2.9.0
-- [Patch] Add `spellCheck` prop to **Input** component
+- [Patch] Add `hasSpellCheck` prop to **Input** component ([#1338](https://github.com/optimizely/oui/pull/1338))
 
 ## 46.3.1 - 2020-05-19
 - [Patch] Export **ManagerSideNav** info for TypeScript ([#1334](https://github.com/optimizely/oui/pull/1334))

--- a/src/components/ExampleComponent/tests/__snapshots__/index.js.snap
+++ b/src/components/ExampleComponent/tests/__snapshots__/index.js.snap
@@ -37,6 +37,7 @@ exports[`components/ExampleComponent should match the Jest Snapshot 1`] = `
     className="oui-example-component"
   >
     <[object Object]
+      hasSpellCheck={true}
       isRequired={false}
       note={null}
       onInput={[Function]}
@@ -49,6 +50,7 @@ exports[`components/ExampleComponent should match the Jest Snapshot 1`] = `
         data-test-section="nameInput"
         onInput={[Function]}
         required={false}
+        spellCheck={true}
         type="text"
       />
     </[object Object]>

--- a/src/components/FilterPicker/tests/__snapshots__/index.js.snap
+++ b/src/components/FilterPicker/tests/__snapshots__/index.js.snap
@@ -120,6 +120,7 @@ exports[`components/FilterPicker with Immutable data (mocked) with CUSTOM keysTo
       </ul>
     </ul>
     <[object Object]
+      hasSpellCheck={true}
       isFilter={true}
       isRequired={false}
       note={null}
@@ -135,6 +136,7 @@ exports[`components/FilterPicker with Immutable data (mocked) with CUSTOM keysTo
         onInput={[Function]}
         placeholder="Browse for Audiences"
         required={false}
+        spellCheck={true}
         type="search"
       />
     </[object Object]>
@@ -752,6 +754,7 @@ exports[`components/FilterPicker with Immutable data (mocked) with DEFAULT keysT
       </ul>
     </ul>
     <[object Object]
+      hasSpellCheck={true}
       isFilter={true}
       isRequired={false}
       note={null}
@@ -767,6 +770,7 @@ exports[`components/FilterPicker with Immutable data (mocked) with DEFAULT keysT
         onInput={[Function]}
         placeholder="Browse for Audiences"
         required={false}
+        spellCheck={true}
         type="search"
       />
     </[object Object]>
@@ -1359,6 +1363,7 @@ exports[`components/FilterPicker with POJO data with CUSTOM keysToSearch and cus
       </ul>
     </ul>
     <[object Object]
+      hasSpellCheck={true}
       isFilter={true}
       isRequired={false}
       note={null}
@@ -1374,6 +1379,7 @@ exports[`components/FilterPicker with POJO data with CUSTOM keysToSearch and cus
         onInput={[Function]}
         placeholder="Browse for Audiences"
         required={false}
+        spellCheck={true}
         type="search"
       />
     </[object Object]>
@@ -1967,6 +1973,7 @@ exports[`components/FilterPicker with POJO data with DEFAULT keysToSearch and cu
       </ul>
     </ul>
     <[object Object]
+      hasSpellCheck={true}
       isFilter={true}
       isRequired={false}
       note={null}
@@ -1982,6 +1989,7 @@ exports[`components/FilterPicker with POJO data with DEFAULT keysToSearch and cu
         onInput={[Function]}
         placeholder="Browse for Audiences"
         required={false}
+        spellCheck={true}
         type="search"
       />
     </[object Object]>

--- a/src/components/Input/Input.story.js
+++ b/src/components/Input/Input.story.js
@@ -34,6 +34,7 @@ stories
         onChange={ action('on change') }
         onBlur={ action('on blur') }
         onKeyDown={ action('on key press') }
+        spellCheck={ boolean('spellCheck', false) }
         placeholder={ text('placeholder', 'just a placeholder') }
         isRequired={ boolean('isRequired', false) }
         type={ select('type', ['text', 'password', 'number', 'date'], 'text') }

--- a/src/components/Input/Input.story.js
+++ b/src/components/Input/Input.story.js
@@ -23,6 +23,7 @@ stories
       <Input
         defaultValue={ text('defaultValue', 'some default value') }
         displayError={ boolean('displayError', false) }
+        hasSpellCheck={ boolean('hasSpellCheck', false) }
         id="input-01"
         isFilter={ boolean('isFilter', false) }
         isDropdown={ boolean('isDropdown', true) }
@@ -34,7 +35,6 @@ stories
         onChange={ action('on change') }
         onBlur={ action('on blur') }
         onKeyDown={ action('on key press') }
-        spellCheck={ boolean('spellCheck', false) }
         placeholder={ text('placeholder', 'just a placeholder') }
         isRequired={ boolean('isRequired', false) }
         type={ select('type', ['text', 'password', 'number', 'date'], 'text') }

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -18,6 +18,9 @@ type InputProps = {
   /** Whether or not to add a clear button to right of input */
   hasClearButton?: boolean;
 
+  /** Disables spell checking when set to false */
+  hasSpellCheck?: boolean;
+
   /** Id of the input to properly associate with the input's label */
   id?: string;
 
@@ -91,9 +94,6 @@ type InputProps = {
   /** Name of the icon to place on right side of input */
   rightIconName?: string;
 
-  /** Disables spellcheck when true */
-  spellCheck?: boolean;
-
   /** Input step value */
   step?: string;
 
@@ -126,6 +126,7 @@ const Input: React.SFC<InputProps> = React.forwardRef(
       displayError,
       focus,
       hasClearButton,
+      hasSpellCheck,
       id,
       isDisabled,
       isFilter,
@@ -147,7 +148,6 @@ const Input: React.SFC<InputProps> = React.forwardRef(
       onKeyDown,
       placeholder,
       rightIconName,
-      spellCheck,
       step,
       testSection,
       textAlign,
@@ -208,7 +208,7 @@ const Input: React.SFC<InputProps> = React.forwardRef(
           onFocus={onFocus}
           min={min}
           max={max}
-          spellCheck={spellCheck}
+          spellCheck={hasSpellCheck}
           step={step}
           {...(typeof maxLength === 'undefined' ? {} : { maxLength })}
           data-test-section={testSection}
@@ -304,7 +304,7 @@ Input.displayName = 'Input';
 Input.defaultProps = {
   note: null,
   isRequired: false,
-  spellCheck: true,
+  hasSpellCheck: true,
 };
 
 export default Input;

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -91,6 +91,9 @@ type InputProps = {
   /** Name of the icon to place on right side of input */
   rightIconName?: string;
 
+  /** Disables spellcheck when true */
+  spellCheck?: boolean;
+
   /** Input step value */
   step?: string;
 
@@ -144,6 +147,7 @@ const Input: React.SFC<InputProps> = React.forwardRef(
       onKeyDown,
       placeholder,
       rightIconName,
+      spellCheck,
       step,
       testSection,
       textAlign,
@@ -204,6 +208,7 @@ const Input: React.SFC<InputProps> = React.forwardRef(
           onFocus={onFocus}
           min={min}
           max={max}
+          spellCheck={spellCheck}
           step={step}
           {...(typeof maxLength === 'undefined' ? {} : { maxLength })}
           data-test-section={testSection}
@@ -299,6 +304,7 @@ Input.displayName = 'Input';
 Input.defaultProps = {
   note: null,
   isRequired: false,
+  spellCheck: true,
 };
 
 export default Input;

--- a/src/components/SearchPicker/tests/__snapshots__/index.js.snap
+++ b/src/components/SearchPicker/tests/__snapshots__/index.js.snap
@@ -28,6 +28,7 @@ exports[`components/SearchPicker default case should render component same as sn
   >
     <div>
       <[object Object]
+        hasSpellCheck={true}
         isFilter={true}
         isRequired={false}
         note={null}
@@ -46,6 +47,7 @@ exports[`components/SearchPicker default case should render component same as sn
           onKeyDown={[Function]}
           placeholder="Search for features"
           required={false}
+          spellCheck={true}
           type="search"
           value=""
         />

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1059,6 +1059,8 @@ declare module "components/Input/index" {
         placeholder?: string;
         /** Name of the icon to place on right side of input */
         rightIconName?: string;
+        /** Disables spellcheck when true */
+        spellCheck?: boolean;
         /** Input step value */
         step?: string;
         /** Hook for automated JavaScript tests */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1007,6 +1007,8 @@ declare module "components/Input/index" {
         focus?: boolean;
         /** Whether or not to add a clear button to right of input */
         hasClearButton?: boolean;
+        /** Disables spell checking when set to false */
+        hasSpellCheck?: boolean;
         /** Id of the input to properly associate with the input's label */
         id?: string;
         /** Prevents input from being modified and appears disabled */
@@ -1059,8 +1061,6 @@ declare module "components/Input/index" {
         placeholder?: string;
         /** Name of the icon to place on right side of input */
         rightIconName?: string;
-        /** Disables spellcheck when true */
-        spellCheck?: boolean;
         /** Input step value */
         step?: string;
         /** Hook for automated JavaScript tests */


### PR DESCRIPTION
## Summary

**What?**
When a user enters a feature key, such as `target_my_mf_rollout `, the spell-checker mark it has an invalid word.

I'm adding a new prop `spellCheck` to the **Input** component so that we can have the option to disable spell checking when it's necessary. 

**Why?**

The Product team requested we disable spell-checking for feature names 

![1](https://user-images.githubusercontent.com/41028823/82474633-eff4fe00-9a90-11ea-8d7f-c69a933e040a.png)
