### PR TITLE
feat(Code): Leverage useTextLabel in Code component copy button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 ## Unreleased
 - [Feature] Add `onMouseEnter` and `onMouseLeave` props to **DropdownBlockLink** ([#1340](https://github.com/optimizely/oui/pull/1340))
 - [Feature] Add ability to have external icon show on hover for **DropdownBlockLinkText** items using `hasExternalIcon` prop ([#1340](https://github.com/optimizely/oui/pull/1340))
+- [Feature] Utilize the new `useTextLabel` prop in the **CopyButton** in **Code** via `copyButtonUsesTextLabel` ([#1342](https://github.com/optimizely/oui/pull/1342))
 - [Patch] Update **Token** and **Sortable** to always use hamburger drag handle by default ([#1337](https://github.com/optimizely/oui/pull/1337))
 - [Patch] Update react-oui-icons version to 2.9.0 ([#1336](https://github.com/optimizely/oui/pull/1336))
     - Update `icons.json` to use latest set of icons from v2.9.0

--- a/src/components/Code/Code.story.js
+++ b/src/components/Code/Code.story.js
@@ -55,6 +55,7 @@ stories
     return (
       <Code
         copyButtonStyle="none"
+        copyButtonUsesTextLabel={ boolean('copyButtonUsesTextLabel', false) }
         hasCopyButton={ boolean('hasCopyButton', true) }
         isHighlighted={ true }
         testSection='my-code-box'

--- a/src/components/Code/index.js
+++ b/src/components/Code/index.js
@@ -74,6 +74,7 @@ class Code extends React.Component {
       type,
       hasCopyButton,
       copyButtonStyle,
+      copyButtonUsesTextLabel,
       testSection,
       className,
       ouiStyle = true,
@@ -94,7 +95,12 @@ class Code extends React.Component {
       <div data-oui-component={ true } className="position--relative">
         { hasCopyButton &&
           <div style={{position: 'absolute', top: '5px', right: '5px' }}>
-            <CopyButton textToCopy={ children } testSection={ testSection } style={ copyButtonStyle }/>
+            <CopyButton
+              textToCopy={ children }
+              usesTextLabel={ copyButtonUsesTextLabel }
+              testSection={ testSection }
+              style={ copyButtonStyle }
+            />
           </div>
         }
         <pre
@@ -125,6 +131,8 @@ Code.propTypes = {
     'unstyled',
     'none',
   ]),
+  /** Copy button displays `Copy` instead of icon */
+  copyButtonUsesTextLabel: PropTypes.bool,
   /** Adds a copy button to code examples */
   hasCopyButton: PropTypes.bool,
   /** Apply syntax highlighting to the code */
@@ -139,6 +147,10 @@ Code.propTypes = {
   testSection: PropTypes.string,
   /** How the code should be displayed */
   type: PropTypes.oneOf(['inline', 'block']).isRequired,
+};
+
+Code.defaultProps = {
+  copyButtonUsesTextLabel: false,
 };
 
 export default Code;

--- a/src/components/Code/tests/index.js
+++ b/src/components/Code/tests/index.js
@@ -113,4 +113,21 @@ describe('components/Code', () => {
 
     expect(component.find('[data-test-section="code-copy-button"]').length).toBe(0);
   });
+
+  it('should add the text `copy` when `copyButtonUsesTextLabel` is true', () => {
+    let code = 'var foo;';
+
+    const component = mount(
+      <Code
+        copyButtonUsesTextLabel={ true }
+        hasCopyButton={ true }
+        testSection="code">
+        { code }
+      </Code>
+    );
+
+    const copyButton = component.find('[data-test-section="code-copy-button"]')
+    expect(copyButton.length).toBe(1);
+    expect(copyButton.text()).toBe('Copy');
+  });
 });


### PR DESCRIPTION
Utilize the newly added `useTextLabel` prop in the `Copy` Component within the `Code` Component.