### PR TITLE
patch(Code): Add maxLineLength prop

### DIFF
--- a/src/components/Code/Code.story.js
+++ b/src/components/Code/Code.story.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
+import { withKnobs, text, boolean, select, number } from '@storybook/addon-knobs';
 import Code from '../Code';
 
 const langOptions = {
@@ -64,6 +64,19 @@ stories
         { text(
           'code', 'var foo = `bar`; var bat = `baz`; var withAReallyReallyLongName = `a value with a really really long string`'
         ) }
+      </Code>
+    );
+  }))
+  .add('With wrapped text', (() => {
+    return (
+      <Code
+        hasCopyButton={ boolean('hasCopyButton', true) }
+        isHighlighted={ boolean('isHighlighted', true) }
+        testSection='my-code-box'
+        type={ select('type', {inline: 'inline', block: 'block'}, 'block') }
+        language={ select('language', langOptions, 'markdown') }
+        maxLineLength={ number('maxLineLength', 100) }>
+        { text('code', '# Optimizely React SDK\n\nThis repository houses the React SDK for use with Optimizely Full Stack and Optimizely Rollouts.\n\nOptimizely Full Stack is A/B testing and feature flag management for product development teams. Experiment in any application. Make every feature on your roadmap an opportunity to learn. Learn more at https://www.optimizely.com/platform/full-stack/, or see the [documentation](https://docs.developers.optimizely.com/full-stack/docs).\n\nOptimizely Rollouts is free feature flags for development teams. Easily roll out and roll back features in any application without code deploys. Mitigate risk for every feature on your roadmap. Learn more at https://www.optimizely.com/rollouts/, or see the [documentation](https://docs.developers.optimizely.com/rollouts/docs).') }
       </Code>
     );
   }));

--- a/src/components/Code/tests/index.js
+++ b/src/components/Code/tests/index.js
@@ -130,4 +130,20 @@ describe('components/Code', () => {
     expect(copyButton.length).toBe(1);
     expect(copyButton.text()).toBe('Copy');
   });
+
+  describe('text wrapping', () => {
+    it('should wrap text when `maxLineLength` is specified', () => {
+      const component = render(
+        <Code type="block" maxLineLength={ 5 }>{ 'helloworldhello' }</Code>
+      );
+      expect(component.text()).toBe('hello\nworld\nhello');
+    });
+
+    it('should not wrap when `type` is "inline"', () => {
+      const component = render(
+        <Code type="inline" maxLineLength={ 5 }>{ 'helloworldhello' }</Code>
+      );
+      expect(component.text()).toBe('helloworldhello');
+    });
+  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -890,6 +890,11 @@ declare module "components/Code/index" {
             isHighlighted: PropTypes.Requireable<boolean>;
             /** Specify a language for the syntax highlighter */
             language: PropTypes.Requireable<string>;
+            /**
+             * (Optional) Wrap each line of props.children to be at most maxLineLength
+             * chars long.
+           */
+            maxLineLength: PropTypes.Requireable<number>;
             /** ouiStyle */
             ouiStyle: PropTypes.Requireable<boolean>;
             /** Hook for automated JavaScript tests */
@@ -899,6 +904,7 @@ declare module "components/Code/index" {
         };
         export namespace defaultProps {
             export const copyButtonUsesTextLabel: boolean;
+            export const maxLineLength: null;
         }
     }
     import React from "react";


### PR DESCRIPTION
Adds a new prop, `maxLineLength`, to the `<Code>` component. When specified, the component wraps each line of props.children to be at most `maxLineLength` characters long.

**Background**

Since #1294 was merged, there's no longer an automatic way to have long code samples wrap when passed to `<Code>`. My hope was that passed code would have newlines embedded in it, instead of the `<Code>` component trying to figure out the best wrapping.

That said, I now think opt-in text wrapping can be useful in some circumstances. For example, if you're displaying one code sample in two locations with different widths, there may not be one "correct" embedding of newlines in the string that looks right in both locations.

**Caveats**

This prop easily breaks syntax highlighting when given values that are too small. Fixing this would require the line wrapping function to run after the syntax highlighter, and only modify text nodes in the output. It's do-able but a bigger effort.