### PR TITLE
update(Disclose): Add flexing to Disclose title and allow title to receive a node or a string.

### DIFF
--- a/src/components/Disclose/index.js
+++ b/src/components/Disclose/index.js
@@ -37,8 +37,8 @@ const Disclose = ({
   return (
     <div className={ arrowClass } style={{marginTop: '-1px'}}>
       <a onClick={ toggle } className={ linkClass }>
-        <div className='oui-disclose__arrow'>
-          <span className="oui-disclose__symbol push-half--right"></span>
+        <div className='flex oui-disclose__arrow'>
+          <span className="oui-disclose__symbol push-half--right" />
           { title }
         </div>
       </a>
@@ -56,7 +56,10 @@ Disclose.propTypes = {
   indented: PropTypes.bool,
   isOpen: PropTypes.bool,
   noBorder: PropTypes.bool,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.oneOf([
+    PropTypes.node,
+    PropTypes.string,
+  ]).isRequired,
   toggle: PropTypes.func,
 };
 


### PR DESCRIPTION
## Summary:
- Added `flex` to `Disclose` title className.
- Updated the `title` of `Disclose` to also take a node or a string for a more flexible title.

Signed-off-by: Son Pham <son.pham@optimizely.com>