### PR TITLE
fix(Tile): TypeScript prop types

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -25,7 +25,7 @@ const a11y = {
   },
 };
 
-const req = require.context('../src/', true, /story\.js$/);
+const req = require.context('../src/', true, /story\.(js|ts)x?$/);
 
 function loadStories() {
   require('./overview.story.js');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Update **Tile** Prop TypeScript definition for `dropdownItems`. Also updated **Tile** stories to be tsx (for TypeScript validation) and the ability for all Stories to use TypeScript. ([#1359](https://github.com/optimizely/oui/pull/1359))
 
 ## 46.6.0 - 2020-06-22
 - [Feature] Add multiple **LayoutKit** stories and ability to specify `alignSelf` on **Col** ([#1357](https://github.com/optimizely/oui/pull/1357))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ Every component should contain prop definitions and a robust set of Storybook ex
 3. Include accurate `propType` configurations and comments, as well as `defaultProps` if applicable (these details are pulled into the _show info_ section)
 4. Create multiple stories to accurately showcase your new/updated component and its various states. When applicable, include [knobs](https://github.com/storybookjs/storybook/blob/master/addons/knobs/README.md) in your story to help others understand the different configurations of props.
 
+**_Tip:_** Use a `.tsx` file extension for your Story to ensure your component is typed correctly
+
 ## ʦ Typescript
 
 Typescript is enabled (_but not required_) in this repo. Typescript is a superset of Javascript which is used to enforce static typing of an otherwise untyped dynamic language. It can be a little confusing at first, so here are some tips for developing with Typescript:

--- a/src/components/Tile/Tile.story.tsx
+++ b/src/components/Tile/Tile.story.tsx
@@ -59,7 +59,7 @@ stories
     return (
       <Container>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Alpha"
               description="ID: 123456"
@@ -71,7 +71,7 @@ stories
               warningContent={<p>Warning details</p>}
             />
           </Col>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Beta: We are buttons"
               description="You can click us!"
@@ -135,7 +135,7 @@ stories
     return (
       <Container>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Alpha"
               description="ID:12345678"
@@ -150,7 +150,7 @@ stories
           </Col>
         </Row>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Beta"
               description="isSelected is true here"
@@ -166,7 +166,7 @@ stories
           </Col>
         </Row>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Charlie"
               description="ID:1357"
@@ -182,7 +182,7 @@ stories
           </Col>
         </Row>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Delta"
               description="ID:2468"
@@ -198,7 +198,7 @@ stories
           </Col>
         </Row>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Echo"
               description="Increase in unique conversions per visitor for Recurring deposit complete event"
@@ -214,7 +214,7 @@ stories
           </Col>
         </Row>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Foxtrot"
               description="All possibilities, as an example. Don't actually do this, please"
@@ -239,7 +239,7 @@ stories
     return (
       <Container>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Alpha"
               description="ID:12345678"
@@ -255,7 +255,7 @@ stories
           </Col>
         </Row>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Beta"
               description="isSelected is true here"
@@ -272,7 +272,7 @@ stories
           </Col>
         </Row>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Charlie"
               description="ID:1357"
@@ -289,7 +289,7 @@ stories
           </Col>
         </Row>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Delta"
               description="ID:2468"
@@ -306,7 +306,7 @@ stories
           </Col>
         </Row>
         <Row>
-          <Col small="6">
+          <Col small={6}>
             <Tile
               name="Zeta"
               description="Increase in unique conversions per visitor for Recurring deposit complete event"

--- a/src/components/Tile/Tile.story.tsx
+++ b/src/components/Tile/Tile.story.tsx
@@ -1,0 +1,327 @@
+import React from "react";
+
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { withKnobs, text, boolean } from "@storybook/addon-knobs";
+
+import Tile from "./index";
+import Col from "../Layout/Col";
+import Row from "../Layout/Row";
+import Container from "../Layout/Container";
+import Dropdown from "../Dropdown";
+
+const stories = storiesOf("Tile", module);
+
+const dropdownItems = [
+  <Dropdown.ListItem key={0} role="separator">
+    Percentage Rollout
+  </Dropdown.ListItem>,
+  <Dropdown.ListItem key={1}>
+    <Dropdown.BlockLink
+      onClick={action("onClick move to top")}
+      testSection={"dropdown-block-link-move"}
+    >
+      <Dropdown.BlockLinkText text={"Move to top"} />
+    </Dropdown.BlockLink>
+  </Dropdown.ListItem>,
+  <Dropdown.ListItem key={2} removeBorderTop={true}>
+    <Dropdown.BlockLink
+      onClick={action("onClick duplicate")}
+      testSection={"dropdown-block-link-duplicate"}
+    >
+      <Dropdown.BlockLinkText text={"Duplicate"} />
+    </Dropdown.BlockLink>
+  </Dropdown.ListItem>,
+  <Dropdown.ListItem key={3} removeBorderTop={true}>
+    <Dropdown.BlockLink
+      onClick={action("onClick archive")}
+      testSection={"dropdown-block-link-archive"}
+    >
+      <Dropdown.BlockLinkText text={"Archive"} />
+    </Dropdown.BlockLink>
+  </Dropdown.ListItem>,
+  <Dropdown.ListItem key={4}>
+    <Dropdown.BlockLink
+      onClick={action("onClick delete")}
+      testSection={"dropdown-block-link-delete"}
+    >
+      <Dropdown.BlockLinkText text={"Delete..."} isDestructive={true} />
+    </Dropdown.BlockLink>
+  </Dropdown.ListItem>,
+];
+
+stories
+  .addDecorator(withKnobs)
+  .addDecorator((story) => <div id="root-preview">{story()}</div>);
+
+stories
+  .add("Interactive (content is a Button)", () => {
+    return (
+      <Container>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Alpha"
+              description="ID: 123456"
+              onTileClick={action("onTileClick - Alpha")}
+              isSelected={boolean("isSelected", false)}
+              isDraggable={boolean("isDraggable", false)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+            />
+          </Col>
+          <Col small="6">
+            <Tile
+              name="Beta: We are buttons"
+              description="You can click us!"
+              onTileClick={action("onTileClick - Beta")}
+              isSelected={boolean("isSelected", false)}
+              isDraggable={boolean("isDraggable", false)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+            />
+          </Col>
+        </Row>
+      </Container>
+    );
+  })
+  .add("Static (content is not a Button)", () => {
+    return (
+      <Tile
+        name="Alpha: I am not a button"
+        description="Clicking me will do nothing"
+        isSelected={boolean("isSelected", false)}
+        isDraggable={boolean("isDraggable", false)}
+        hasWarning={boolean("hasWarning", false)}
+        warningTitle={text("warningText", "This is a warning")}
+        warningContent={<p>Warning details</p>}
+      />
+    );
+  })
+  .add("With Monospace Name", () => {
+    return (
+      <Tile
+        name="amount"
+        description="double"
+        usesMonospaceName={boolean("usesMonospaceName", true)}
+        onTileClick={action("onTileClick")}
+        isSelected={boolean("isSelected", false)}
+        isDraggable={boolean("isDraggable", false)}
+        hasWarning={boolean("hasWarning", false)}
+        warningTitle={text("warningText", "This is a warning")}
+        warningContent={<p>Warning details</p>}
+        onCopy={action("onCopy called")}
+      />
+    );
+  })
+  .add("Draggable, with a warning", () => {
+    return (
+      <Tile
+        name="Alpha"
+        description="ID:12345678"
+        onTileClick={action("onTileClick")}
+        isSelected={boolean("isSelected", false)}
+        isDraggable={boolean("isDraggable", true)}
+        hasWarning={boolean("hasWarning", true)}
+        warningTitle={text("warningText", "This is a warning")}
+        warningContent={<p>Warning details</p>}
+        testSection="with-warning"
+      />
+    );
+  })
+  .add("With Action Items on the right", () => {
+    return (
+      <Container>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Alpha"
+              description="ID:12345678"
+              onTileClick={action("onTileClick")}
+              isSelected={boolean("isSelected", false)}
+              isDraggable={boolean("isDraggable", false)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+              onDismiss={action("onDismiss called")}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Beta"
+              description="isSelected is true here"
+              onTileClick={action("onTileClick")}
+              isSelected={true}
+              isDraggable={boolean("isDraggable", false)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+              status="Archived"
+              onDismiss={action("onDismiss called")}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Charlie"
+              description="ID:1357"
+              onTileClick={action("onTileClick")}
+              isSelected={boolean("isSelected", false)}
+              isDraggable={boolean("isDraggable", false)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+              onDismiss={action("onDismiss called")}
+              onEdit={action("onEdit called")}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Delta"
+              description="ID:2468"
+              onTileClick={action("onTileClick")}
+              isSelected={boolean("isSelected", false)}
+              isDraggable={boolean("isDraggable", false)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+              status="Running"
+              dropdownItems={dropdownItems}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Echo"
+              description="Increase in unique conversions per visitor for Recurring deposit complete event"
+              onTileClick={action("onTileClick")}
+              isSelected={boolean("isSelected", false)}
+              isDraggable={boolean("isDraggable", false)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+              onCopy={action("onCopy called")}
+              dropdownItems={dropdownItems}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Foxtrot"
+              description="All possibilities, as an example. Don't actually do this, please"
+              onTileClick={action("onTileClick")}
+              isSelected={boolean("isSelected", false)}
+              isDraggable={boolean("isDraggable", true)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+              status="Active"
+              onCopy={action("onCopy called")}
+              onDismiss={action("onDismiss called")}
+              onEdit={action("onEdit called")}
+              dropdownItems={dropdownItems}
+            />
+          </Col>
+        </Row>
+      </Container>
+    );
+  })
+  .add("With Ordering", () => {
+    return (
+      <Container>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Alpha"
+              description="ID:12345678"
+              order={1}
+              onTileClick={action("onTileClick")}
+              isSelected={boolean("isSelected", false)}
+              isDraggable={boolean("isDraggable", true)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+              onDismiss={action("onDismiss called")}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Beta"
+              description="isSelected is true here"
+              order={2}
+              onTileClick={action("onTileClick")}
+              isSelected={true}
+              isDraggable={boolean("isDraggable", true)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+              status="Archived"
+              onDismiss={action("onDismiss called")}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Charlie"
+              description="ID:1357"
+              order={3}
+              onTileClick={action("onTileClick")}
+              isSelected={boolean("isSelected", false)}
+              isDraggable={boolean("isDraggable", true)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+              onDismiss={action("onDismiss called")}
+              onEdit={action("onEdit called")}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Delta"
+              description="ID:2468"
+              order={4}
+              onTileClick={action("onTileClick")}
+              isSelected={boolean("isSelected", false)}
+              isDraggable={boolean("isDraggable", true)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+              status="Running"
+              dropdownItems={dropdownItems}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col small="6">
+            <Tile
+              name="Zeta"
+              description="Increase in unique conversions per visitor for Recurring deposit complete event"
+              order={99}
+              onTileClick={action("onTileClick")}
+              isSelected={boolean("isSelected", false)}
+              isDraggable={boolean("isDraggable", true)}
+              hasWarning={boolean("hasWarning", false)}
+              warningTitle={text("warningText", "This is a warning")}
+              warningContent={<p>Warning details</p>}
+              onCopy={action("onCopy called")}
+              dropdownItems={dropdownItems}
+            />
+          </Col>
+        </Row>
+      </Container>
+    );
+  });

--- a/src/components/Tile/index.tsx
+++ b/src/components/Tile/index.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
-import classNames from 'classnames';
+import React from "react";
+import classNames from "classnames";
 
-import Button from '../Button';
-import OverlayWrapper from '../OverlayWrapper';
-import Popover from '../Popover';
-import Dropdown from '../Dropdown';
-import ButtonIcon from '../ButtonIcon';
-import Icon from 'react-oui-icons';
+import Button from "../Button";
+import OverlayWrapper from "../OverlayWrapper";
+import Popover from "../Popover";
+import Dropdown from "../Dropdown";
+import ButtonIcon from "../ButtonIcon";
+import Icon from "react-oui-icons";
 
-import { greyDark } from '../../tokens/forimport/index.es';
-
+import { greyDark } from "../../tokens/forimport/index.es";
 
 const renderDropdownActivator = (
   { onClick, buttonRef } // eslint-disable-line
@@ -22,30 +21,6 @@ const renderDropdownActivator = (
     onClick={onClick}
   />
 );
-
-const renderTileActions = (
-  items: ListItemTypeProps[],
-) => {
-  return (
-    <Dropdown
-      renderActivator={renderDropdownActivator}
-      placement={'bottom-end'}
-      key="dropdown"
-    >
-      <Dropdown.Contents direction={'right'}>
-        {items}
-      </Dropdown.Contents>
-    </Dropdown>
-  );
-};
-
-type ListItemTypeProps =  {
-  hardSides?: boolean,
-  hardTop?: boolean,
-  ignoreToggle?: boolean,
-  removeBorderTop?: boolean,
-  role?: string,
-}
 
 export type TileProps = {
   /**
@@ -63,7 +38,7 @@ export type TileProps = {
    * Optional dropdown items to add to right side of Tile
    * Should be an array of Dropdown.ListItem items
    */
-  dropdownItems?: ListItemTypeProps[];
+  dropdownItems?: React.ReactNode[];
 
   /**
    * Whether or not this Tile has margin on the ends
@@ -167,26 +142,28 @@ const Tile = ({
   status,
   testSection,
   usesMonospaceName = false,
-  warningContent = '',
+  warningContent = "",
   warningTitle,
 }: TileProps) => {
   const tileContent = (
     <>
       <p
-        className={classNames('text--left flush', {
+        className={classNames("text--left flush", {
           monospace: usesMonospaceName,
         })}
       >
         {name}
       </p>
-      <p className="text--left muted flush--bottom push-half--top micro wrap-text">{description}</p>
+      <p className="text--left muted flush--bottom push-half--top micro wrap-text">
+        {description}
+      </p>
     </>
   );
   return (
     <div
-      className={classNames('oui-tile flex flex-align--center soft', {
-        'oui-tile--selected': isSelected,
-        'push-half--ends': hasSpacing,
+      className={classNames("oui-tile flex flex-align--center soft", {
+        "oui-tile--selected": isSelected,
+        "push-half--ends": hasSpacing,
       })}
       data-test-section={testSection}
     >
@@ -260,7 +237,17 @@ const Tile = ({
             onClick={onDismiss}
           />
         )}
-        {dropdownItems && renderTileActions(dropdownItems)}
+        {dropdownItems && (
+          <Dropdown
+            renderActivator={renderDropdownActivator}
+            placement={"bottom-end"}
+            key="dropdown"
+          >
+            <Dropdown.Contents direction={"right"}>
+              {dropdownItems}
+            </Dropdown.Contents>
+          </Dropdown>
+        )}
       </div>
     </div>
   );

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1949,13 +1949,7 @@ declare module "components/DragAndDrop/index" {
     import PropTypes from "prop-types";
 }
 declare module "components/Tile/index" {
-    type ListItemTypeProps = {
-        hardSides?: boolean;
-        hardTop?: boolean;
-        ignoreToggle?: boolean;
-        removeBorderTop?: boolean;
-        role?: string;
-    };
+    import React from "react";
     export type TileProps = {
         /**
          * Description of the item for this reference Tile
@@ -1970,7 +1964,7 @@ declare module "components/Tile/index" {
          * Optional dropdown items to add to right side of Tile
          * Should be an array of Dropdown.ListItem items
          */
-        dropdownItems?: ListItemTypeProps[];
+        dropdownItems?: React.ReactNode[];
         /**
          * Whether or not this Tile has margin on the ends
          * True by default
@@ -6205,9 +6199,6 @@ declare module "components/Textarea/example/index" {
     }[];
     export default _default;
 }
-declare module "components/Tile/Tile.story" {
-    export {};
-}
 declare module "components/Token/Token.story" {
     export {};
 }
@@ -6366,3 +6357,4 @@ declare module "components/Toolbar/index" {
 declare module "components/Toolbar/Toolbar.story" {
     export {};
 }
+declare module "components/Tile/Tile.story" { }


### PR DESCRIPTION
# Summary:
- Updated **Tile** Prop TypeScript definition for `dropdownItems`.
- Updated **Tile** stories to be tsx (for TypeScript validation) and the ability for all Stories to use TypeScript.
- Reran `yarn generate-types` for changed prop type

Related to [this discussion](https://optimizely.slack.com/archives/CNPTR622U/p1592865204388000) in Slack, this will use the `React.ReactNode` Type since Dropdown doesn't have exported types. The current usage was causing this component to not be used in WIP PRs for Flags.
