### PR TITLE
patch(Dropdown) [UXENG-138] Changed string to node for DropdownBlockLinkText and DropdownBlockLinkSecondaryText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 
 ## Unreleased
 - [Release] Remove `word-break` helper class in favor of `word-break--all` ([#1394](https://github.com/optimizely/oui/pull/1394))
+- [Patch] Replaced `name` and `secondaryText`'s string requirement to node for **Dropdown** ([#1395](https://github.com/optimizely/oui/pull/1395))
 
 ## 46.13.0 - 2020-08-05
 - [Feature] Update Storybook to organize components ([#1381](https://github.com/optimizely/oui/pull/1381))

--- a/src/components/Dropdown/DropdownBlockLinkSecondaryText/index.js
+++ b/src/components/Dropdown/DropdownBlockLinkSecondaryText/index.js
@@ -27,7 +27,7 @@ DropdownBlockLinkSecondaryText.propTypes = {
   /** should show info icon */
   isWarning: PropTypes.bool,
   /** description text, if provided */
-  secondaryText: PropTypes.string,
+  secondaryText: PropTypes.node,
   /** test section from parent */
   testSection: PropTypes.string,
 };

--- a/src/components/Dropdown/DropdownBlockLinkSecondaryText/tests/index.js
+++ b/src/components/Dropdown/DropdownBlockLinkSecondaryText/tests/index.js
@@ -9,6 +9,11 @@ describe('components/Dropdown/DropdownBlockLinkSecondaryText', () => {
   });
 
   it('should render secondary text', () => {
+    const component = shallow(<DropdownBlockLinkSecondaryText secondaryText={ <span>foo</span> } />);
+    expect(component.text()).toBe('foo');
+  });
+
+  it('should render secondary text when passed a span', () => {
     const component = shallow(<DropdownBlockLinkSecondaryText secondaryText={ 'foo' } />);
     expect(component.text()).toBe('foo');
   });

--- a/src/components/Dropdown/DropdownBlockLinkSecondaryText/tests/index.js
+++ b/src/components/Dropdown/DropdownBlockLinkSecondaryText/tests/index.js
@@ -9,12 +9,12 @@ describe('components/Dropdown/DropdownBlockLinkSecondaryText', () => {
   });
 
   it('should render secondary text', () => {
-    const component = shallow(<DropdownBlockLinkSecondaryText secondaryText={ <span>foo</span> } />);
+    const component = shallow(<DropdownBlockLinkSecondaryText secondaryText={ 'foo' } />);
     expect(component.text()).toBe('foo');
   });
 
   it('should render secondary text when passed a span', () => {
-    const component = shallow(<DropdownBlockLinkSecondaryText secondaryText={ 'foo' } />);
+    const component = shallow(<DropdownBlockLinkSecondaryText secondaryText={ <span>foo</span> } />);
     expect(component.text()).toBe('foo');
   });
 

--- a/src/components/Dropdown/DropdownBlockLinkText/index.js
+++ b/src/components/Dropdown/DropdownBlockLinkText/index.js
@@ -34,5 +34,5 @@ DropdownBlockLinkText.propTypes = {
   /** test section from parent */
   testSection: PropTypes.string,
   /** text, if provided */
-  text: PropTypes.string,
+  text: PropTypes.node,
 };

--- a/src/components/Dropdown/DropdownBlockLinkText/tests/index.js
+++ b/src/components/Dropdown/DropdownBlockLinkText/tests/index.js
@@ -13,6 +13,11 @@ describe('components/Dropdown/DropdownBlockLinkText', () => {
     expect(component.text()).toBe('foo');
   });
 
+  it('should render text when passed a span', () => {
+    const component = shallow(<DropdownBlockLinkText text={ <span>foo</span> } />);
+    expect(component.text()).toBe('foo');
+  });
+
   it('should render with test section', () => {
     const component = shallow(<DropdownBlockLinkText testSection="goose"></DropdownBlockLinkText>);
     expect(component.is('[data-test-section="block-link-text-goose"]')).toBe(true);


### PR DESCRIPTION
## Summary

Changed string to node for DropdownBlockLinkText and DropdownBlockLinkSecondaryText's props `name` and `secondaryText` respectively.

## JIRA

[UXENG-138](https://optimizely.atlassian.net/browse/UXENG-138)