### PR TITLE
fix (Tile) Allow Tile to render string or React element as description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Updated **Tile** to allow React Element as description prop ([#1410](https://github.com/optimizely/oui/pull/1410))
 - [Feature] Updated **SelectDropdown** with `label`, `note`, and `isRequired` props ([#1408](https://github.com/optimizely/oui/pull/1408))
 - [Feature] Added new Storybook examples detailing div styling helper classes ([#1391](https://github.com/optimizely/oui/pull/1391))
 

--- a/src/components/Tile/index.tsx
+++ b/src/components/Tile/index.tsx
@@ -26,7 +26,7 @@ export type TileProps = {
   /**
    * Description of the item for this reference Tile
    */
-  description?: string;
+  description?: string | React.ReactNode;
 
   /**
    * Optional properties to include when using Tile


### PR DESCRIPTION
## Summary

Updated **Tile** to allow React Element as description prop

## Changelog Entry

[Patch] Updated **Tile** to allow React Element as description prop

## Test Plan

Manual test

## Jira
