### PR TITLE
fix(SelectDropdown): Fixed Label click firing twice in Multiselect mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Fixed `DropdownBlockLink` firing `click` event twice when Checkbox label is clicked. ([#1417](https://github.com/optimizely/oui/pull/1417))
 
 ## 48.2.0 - 2020-09-11
 - [Feature] Update styling options for **Token** (`backgroundColor` and `name`) and **TokensInput** (`hasSearchIcon` and `isDisabled`) ([#1416](https://github.com/optimizely/oui/pull/1416))

--- a/src/components/BlockList/BlockList.story.js
+++ b/src/components/BlockList/BlockList.story.js
@@ -141,7 +141,7 @@ stories
         <BlockList.Item>View Results</BlockList.Item></BlockList> }
       shouldHideOnClick={ true } verticalAttachment="top" verticalTargetAttachment="bottom">
       <Button style="unstyled" width="default">
-                ...
+        ...
       </Button>
     </OverlayWrapper>
   </div>)))
@@ -155,7 +155,7 @@ stories
           est vitae, ullamcorper neque. Proin efficitur porttitor nunc quis suscipit. Maecenas odio elit, varius et aliquam ac.
         </BlockList.Item>
         <BlockList.Item>
-            https://wwww.example.com/path1/path2/path3/path4/path5/superlongvaluethatdoesntfitintheblocklistwhenitgetsveryveryveryveryveryveryveryveryverylong
+          https://wwww.example.com/path1/path2/path3/path4/path5/superlongvaluethatdoesntfitintheblocklistwhenitgetsveryveryveryveryveryveryveryveryverylong
         </BlockList.Item>
       </BlockList.Category>
     </BlockList>

--- a/src/components/BlockList/example/index.js
+++ b/src/components/BlockList/example/index.js
@@ -132,13 +132,13 @@ export default [
       <OverlayWrapper
         overlay={ <BlockList>
           <BlockList.Item onClick={ mockFunction }>
-              Archive
+            Archive
           </BlockList.Item>
           <BlockList.Item onClick={ mockFunction }>
-              Pause
+            Pause
           </BlockList.Item>
           <BlockList.Item onClick={ mockFunction }>
-              View Results
+            View Results
           </BlockList.Item>
         </BlockList> }
         horizontalAttachment="left"

--- a/src/components/Button/Button.story.js
+++ b/src/components/Button/Button.story.js
@@ -115,7 +115,7 @@ stories
             style="highlight"
             onClick={ action('I have been clicked') }
             rightIcon='external'>
-          Right icon
+            Right icon
           </Button>,
           <Button
             key="3"
@@ -200,7 +200,7 @@ stories
         style="highlight"
         isLoading={ boolean('isLoading', true) }
         onClick={ action('I have been clicked') }>
-          Create Campaign
+        Create Campaign
       </Button>
     );
   })
@@ -211,7 +211,7 @@ stories
         isLoading={ boolean('isLoading', true) }
         loadingText={ text('loadingText', 'Creating Campaign') }
         onClick={ action('I have been clicked') }>
-          Create Campaign
+        Create Campaign
       </Button>
     );
   });

--- a/src/components/Disclose/Disclose.story.js
+++ b/src/components/Disclose/Disclose.story.js
@@ -20,8 +20,8 @@ stories.add('Default', (() => {
     <Disclose title='default title'>
       <h3>Some Title</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Commodi id voluptas vitae eius
-      expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
-      accusantium corporis, beatae maxime quasi. Tempora.</p>
+        expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
+        accusantium corporis, beatae maxime quasi. Tempora.</p>
     </Disclose>
   );
 }));
@@ -33,16 +33,16 @@ stories.add('Multiple stacked', (() => {
         <div className='soft--left'>
           <h3>Some Title</h3>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Commodi id voluptas vitae eius
-          expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
-          accusantium corporis, beatae maxime quasi. Tempora.</p>
+            expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
+            accusantium corporis, beatae maxime quasi. Tempora.</p>
         </div>
       </Disclose>
       <Disclose headerStyle='header-bordered' title='Some Title'>
         <div className='soft--left'>
           <h3>Some Title</h3>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Commodi id voluptas vitae eius
-          expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
-          accusantium corporis, beatae maxime quasi. Tempora.</p>
+            expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
+            accusantium corporis, beatae maxime quasi. Tempora.</p>
         </div>
       </Disclose>
     </div>
@@ -62,8 +62,8 @@ stories.add('Header style', (() => {
         <div className='soft--left'>
           <h3>Some Title</h3>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Commodi id voluptas vitae eius
-          expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
-          accusantium corporis, beatae maxime quasi. Tempora.</p>
+            expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
+            accusantium corporis, beatae maxime quasi. Tempora.</p>
         </div>
       </Disclose>
     </div>
@@ -76,14 +76,14 @@ stories.add('With divider', (() => {
       <Disclose childrenStyle='divider' title='Some Title'>
         <h3>Some Title</h3>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Commodi id voluptas vitae eius
-        expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
-        accusantium corporis, beatae maxime quasi. Tempora.</p>
+          expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
+          accusantium corporis, beatae maxime quasi. Tempora.</p>
       </Disclose>
       <Disclose childrenStyle='divider' title='Some Title'>
         <h3>Some Title</h3>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Commodi id voluptas vitae eius
-        expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
-        accusantium corporis, beatae maxime quasi. Tempora.</p>
+          expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
+          accusantium corporis, beatae maxime quasi. Tempora.</p>
       </Disclose>
     </div>
   );

--- a/src/components/Disclose/example/index.js
+++ b/src/components/Disclose/example/index.js
@@ -8,10 +8,10 @@ export default [
       <Disclose title='Some Title'>
         <h3>Some Title</h3>
         <p>Lorem ipsum dolor sit amet, consectetur
-         adipisicing elit. Commodi id voluptas vitae eius
-         expedita alias iste deserunt rndis earum
-         voluptatibus quae, numquam dolorum perspiciatis
-         accusantium corporis, beatae maxime quasi. Tempora.</p>
+          adipisicing elit. Commodi id voluptas vitae eius
+          expedita alias iste deserunt rndis earum
+          voluptatibus quae, numquam dolorum perspiciatis
+          accusantium corporis, beatae maxime quasi. Tempora.</p>
       </Disclose>,
     ],
   },

--- a/src/components/DiscloseTable/DiscloseTable.story.js
+++ b/src/components/DiscloseTable/DiscloseTable.story.js
@@ -97,8 +97,8 @@ stories
                   <Table.TR>
                     <Table.TD>
                       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Commodi id voluptas vitae eius
-                                  expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
-                                  accusantium corporis, beatae maxime quasi. Tempora.</p>
+                        expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
+                        accusantium corporis, beatae maxime quasi. Tempora.</p>
                     </Table.TD>
                   </Table.TR>
                 </Table.TBody>
@@ -122,8 +122,8 @@ stories
           ]
           }>
           <p className="soft--sides">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Commodi id voluptas vitae eius
-          expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
-          accusantium corporis, beatae maxime quasi. Tempora.</p>
+            expedita alias iste deserunt rndis earum voluptatibus quae, numquam dolorum perspiciatis
+            accusantium corporis, beatae maxime quasi. Tempora.</p>
         </DiscloseTable.Row>
       </Table.TBody>
     </DiscloseTable>

--- a/src/components/DockedFooter/DockedFooter.story.js
+++ b/src/components/DockedFooter/DockedFooter.story.js
@@ -45,10 +45,10 @@ const ScrollContainer = function({
         includesMargin={ true }
         rightGroup={ !hasCenterGroup && [
           <Button style="plain" key={ 0 } onClick={ noop }>
-              Cancel
+            Cancel
           </Button>,
           <Button style="highlight" key={ 1 } onClick={ noop }>
-              Confirm
+            Confirm
           </Button>,
         ] }
         centerGroup={ hasCenterGroup && [

--- a/src/components/Dropdown/DropdownBlockLink/index.js
+++ b/src/components/Dropdown/DropdownBlockLink/index.js
@@ -44,11 +44,11 @@ export const DropdownBlockLink = props => {
       style={ styleProps }
       { ...(props.testSection ? { 'data-test-section': props.testSection } : {}) }
       { ...(props.trackId ? { 'data-track-id': props.trackId } : {}) }
-      { ...(!props.isMultiSelect ? {onClick} : {}) }
+      { ...(!props.isMultiSelect ? { onClick } : {}) }
       onMouseEnter={ onMouseEnter }
       onMouseLeave={ onMouseLeave }>
       {props.isMultiSelect ? (
-        <Checkbox onChange={onClick} defaultChecked={ props.isItemSelected } label={ props.children } isDisabled={ false } />
+        <Checkbox onChange={ onClick } defaultChecked={ props.isItemSelected } label={ props.children } isDisabled={ false } />
       ) : (
         props.children
       )}

--- a/src/components/Dropdown/DropdownBlockLink/index.js
+++ b/src/components/Dropdown/DropdownBlockLink/index.js
@@ -44,11 +44,11 @@ export const DropdownBlockLink = props => {
       style={ styleProps }
       { ...(props.testSection ? { 'data-test-section': props.testSection } : {}) }
       { ...(props.trackId ? { 'data-track-id': props.trackId } : {}) }
-      onClick={ onClick }
+      { ...(!props.isMultiSelect ? {onClick} : {}) }
       onMouseEnter={ onMouseEnter }
       onMouseLeave={ onMouseLeave }>
       {props.isMultiSelect ? (
-        <Checkbox defaultChecked={ props.isItemSelected } label={ props.children } isDisabled={ false } />
+        <Checkbox onChange={onClick} defaultChecked={ props.isItemSelected } label={ props.children } isDisabled={ false } />
       ) : (
         props.children
       )}

--- a/src/components/Dropdown/DropdownBlockLink/tests/__snapshots__/index.js.snap
+++ b/src/components/Dropdown/DropdownBlockLink/tests/__snapshots__/index.js.snap
@@ -10,7 +10,6 @@ exports[`components/Dropdown/DropdownBlockLink should add a checked checkbox whe
 >
   <div
     className="link oui-dropdown__block-link"
-    onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
     style={Object {}}
@@ -20,6 +19,7 @@ exports[`components/Dropdown/DropdownBlockLink should add a checked checkbox whe
       isDisabled={false}
       label="foo"
       labelWeight="normal"
+      onChange={[Function]}
     >
       <Label>
         <label
@@ -34,6 +34,7 @@ exports[`components/Dropdown/DropdownBlockLink should add a checked checkbox whe
               data-oui-component={true}
               defaultChecked={true}
               disabled={false}
+              onChange={[Function]}
               style={
                 Object {
                   "marginTop": "0.35em",

--- a/src/components/ExampleComponent/ExampleComponent.story.js
+++ b/src/components/ExampleComponent/ExampleComponent.story.js
@@ -90,7 +90,7 @@ storiesOf('Overview|Examples', module)
             <React.Fragment>
               <h1>Example OUI Component</h1>
               <p>
-                  This component uses the <a href="https://reactjs.org/docs/render-props.html" target="_blank" rel="noopener noreferrer">render props</a> pattern to allow for more extensibility while abstracting some common complexity. Check out the README in the "Show Info" section for more info!
+                This component uses the <a href="https://reactjs.org/docs/render-props.html" target="_blank" rel="noopener noreferrer">render props</a> pattern to allow for more extensibility while abstracting some common complexity. Check out the README in the "Show Info" section for more info!
               </p>
               <p className="micro"><span className="example-background--yellow">This text has its background color changed</span> by the ExampleComponent's sass.</p>
               <h3 className="push-double--top">Abstrating State Management</h3>

--- a/src/components/HelpPopover/HelpPopover.story.js
+++ b/src/components/HelpPopover/HelpPopover.story.js
@@ -28,7 +28,7 @@ stories
         behavior="hover"
         horizontalAttachment="left"
         verticalAttachment="middle">
-       You hovered! 🤓
+        You hovered! 🤓
       </HelpPopover>
     </div>
   </div>)))
@@ -40,7 +40,7 @@ stories
         behavior="hover"
         horizontalAttachment="left"
         verticalAttachment="middle">
-       You hovered! 🤓
+        You hovered! 🤓
       </HelpPopover>
     </Row>
   </div>)));

--- a/src/components/ManagerSideNav/ManagerSideNav.story.js
+++ b/src/components/ManagerSideNav/ManagerSideNav.story.js
@@ -229,7 +229,7 @@ stories
         <p>
           Using the classes
           <em><code> oui-manager-side-nav__custom-link </code></em>
-           and
+          and
           <code><em> oui-manager-side-nav__custom-link--active</em></code>,
           you can use a custom link for the nav item content and get consistent styling
         </p>

--- a/src/components/OverlayWrapper/example/index.js
+++ b/src/components/OverlayWrapper/example/index.js
@@ -12,8 +12,8 @@ export default [
         <OverlayWrapper
           overlay={ <Popover title="Lorem ipsum dolor sit amet">
             <p>
-                Ipsa officiis bad-news minus earum a aperiam! Aperiam reiciendis vitae
-                nihil libero et, hic!
+              Ipsa officiis bad-news minus earum a aperiam! Aperiam reiciendis vitae
+              nihil libero et, hic!
             </p>
           </Popover> }>
           <Button>Open Popover</Button>
@@ -27,8 +27,8 @@ export default [
         <OverlayWrapper
           overlay={ <Popover title="Lorem ipsum dolor sit amet">
             <p>
-                Ipsa officiis bad-news minus earum a aperiam! Aperiam reiciendis vitae
-                nihil libero et, hic!
+              Ipsa officiis bad-news minus earum a aperiam! Aperiam reiciendis vitae
+              nihil libero et, hic!
             </p>
           </Popover> }
           horizontalAttachment="left"
@@ -47,8 +47,8 @@ export default [
         <OverlayWrapper
           overlay={ <Popover>
             <p>
-                The close button works because `OverlayWrapper` exposes a
-                `hideOverlay` method using `context` in React.
+              The close button works because `OverlayWrapper` exposes a
+              `hideOverlay` method using `context` in React.
             </p>
             <p>See the source for `OverlayWrapper` to learn more.</p>
           </Popover> }>
@@ -63,8 +63,8 @@ export default [
         <OverlayWrapper
           overlay={ <Popover title="Lorem ipsum dolor sit amet">
             <p>
-                Ipsa officiis bad-news minus earum a aperiam! Aperiam reiciendis vitae
-                nihil libero et, hic!
+              Ipsa officiis bad-news minus earum a aperiam! Aperiam reiciendis vitae
+              nihil libero et, hic!
             </p>
           </Popover> }
           horizontalAttachment="left"
@@ -82,8 +82,8 @@ export default [
         <OverlayWrapper
           overlay={ <Popover title="Lorem ipsum dolor sit amet">
             <p>
-                Ipsa officiis bad-news minus earum a aperiam! Aperiam reiciendis vitae
-                nihil libero et, hic!
+              Ipsa officiis bad-news minus earum a aperiam! Aperiam reiciendis vitae
+              nihil libero et, hic!
             </p>
           </Popover> }
           shouldHideOnClick={ false }>

--- a/src/components/Sortable/SortDragLayer/index.js
+++ b/src/components/Sortable/SortDragLayer/index.js
@@ -60,6 +60,7 @@ class SortDragLayer extends React.Component {
       ]).isRequired,
       id: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
       position: PropTypes.arrayOf(PropTypes.number).isRequired,
+      type: PropTypes.string,
     }),
     renderItem: PropTypes.func.isRequired,
   };

--- a/src/components/Spinner/Spinner.story.js
+++ b/src/components/Spinner/Spinner.story.js
@@ -26,8 +26,8 @@ stories.add('With overlay', () => {
   return (
     <div className="position--relative">
       <div>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Non cum iusto repudiandae
-      earum porro reprehenderit perspiciatis iste delectus ipsam, accusantium ad sunt,
-      rem mollitia, omnis illum explicabo facere quibusdam qui.</div>
+        earum porro reprehenderit perspiciatis iste delectus ipsam, accusantium ad sunt,
+        rem mollitia, omnis illum explicabo facere quibusdam qui.</div>
       <Spinner hasOverlay={ true } />
     </div>
   );


### PR DESCRIPTION
## Summary

When `multiSelect` is enabled, the `onClick` event fires twice when checkbox label is clicked. It fires once when actual checkbox is clicked directly. Fixed it by moving the event from `div` to `Checkbox` when `multiSelect` is enabled.

## Changelog Entry
[Patch] Fixed `DropdownBlockLink` firing `click` event twice when Checkbox label is clicked.

## Test Plan
- Manually tested thoroughly.
- Modified existing unit test to test the fix.

## Jira