### PR TITLE
feat (Tile) Add support for results link in Tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Feature] Updated **Tile** to support new optional prop `onResultsLink` ([#1418](https://github.com/optimizely/oui/pull/1418))
 
 ## 48.2.0 - 2020-09-11
 - [Feature] Update styling options for **Token** (`backgroundColor` and `name`) and **TokensInput** (`hasSearchIcon` and `isDisabled`) ([#1416](https://github.com/optimizely/oui/pull/1416))

--- a/src/components/Tile/Tile.story.tsx
+++ b/src/components/Tile/Tile.story.tsx
@@ -234,6 +234,7 @@ stories
               onCopy={action("onCopy called")}
               onDismiss={action("onDismiss called")}
               onEdit={action("onEdit called")}
+              onResultsLink={action("onResultsLink called")}
               dropdownItems={dropdownItems}
             />
           </Col>

--- a/src/components/Tile/index.tsx
+++ b/src/components/Tile/index.tsx
@@ -83,6 +83,13 @@ export type TileProps = {
   onEdit?: (...args: any[]) => any;
 
   /**
+   * Function to call when results button is clicked
+   * Supplying this function adds a results button
+   * to the tile
+   */
+  onResultsLink?: (...args: any[]) => any;
+
+  /**
    * Function to call when the main area of the Tile is clicked
    * If function is not supplied, main content of the Tile
    * will not be clickable (div instead of a button)
@@ -137,6 +144,7 @@ const Tile = ({
   onCopy,
   onDismiss,
   onEdit,
+  onResultsLink,
   onTileClick,
   order,
   status,
@@ -160,7 +168,7 @@ const Tile = ({
     </>
   );
   const hasExtraContent =
-    status || onCopy || onEdit || onDismiss || dropdownItems;
+    status || onCopy || onEdit || onDismiss || onResultsLink || dropdownItems;
   return (
     <div
       className={classNames('oui-tile flex flex-align--center soft--sides', {
@@ -243,6 +251,15 @@ const Tile = ({
               style="plain"
               iconFill="default"
               onClick={onDismiss}
+            />
+          )}
+          {onResultsLink && (
+            <ButtonIcon
+              iconName="winner"
+              size="medium"
+              style="plain"
+              iconFill="default"
+              onClick={onResultsLink}
             />
           )}
           {dropdownItems && (

--- a/src/components/Tile/tests/index.js
+++ b/src/components/Tile/tests/index.js
@@ -66,6 +66,7 @@ describe('components/Tile', () => {
     const mockDeleteClick = jest.fn();
     const mockCopyClick = jest.fn();
     const mockEditClick = jest.fn();
+    const mockResultsClick = jest.fn();
 
     console.error = jest.fn();
     const component = mount(
@@ -76,9 +77,10 @@ describe('components/Tile', () => {
         onCopy={ mockCopyClick }
         onDismiss={ mockDeleteClick }
         onEdit={ mockEditClick }
+        onResultsLink={ mockResultsClick }
       />
     );
-    expect(component.find('.oui-button-icon').length).toBe(3);
+    expect(component.find('.oui-button-icon').length).toBe(4);
   });
 
   it('should render the title in monospace when `usesMonospaceTitle` is true', () => {


### PR DESCRIPTION
## Summary

Adding support for a link to results from Tile, to match Velociraptor designs:
![image](https://user-images.githubusercontent.com/2287470/93131402-fc394280-f6a1-11ea-9b6a-4d8887584306.png)

I chose to make it a specific prop to keep it inline with the other button props in Tile.

## Changelog Entry

<!-- Please describe in one line your changes, like so: [Feature] Updated **ComponentName** with new `propName` to fix alignment -->
[Feature] Updated **Tile** to support new optional prop `onResultsLink`

## Test Plan

Updated unit test

## Jira
