### PR TITLE
feat(Badge): Added Background Color support to Badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Feature] Updated **Badge** with new `backgroundColor` to support additional colors. ([#1423](https://github.com/optimizely/oui/pull/1423))
 
 ## 48.3.3 - 2020-09-24
 - [Patch] Updated **ButtonIcon** component to be memoized to improve usage performance ([#1422](https://github.com/optimizely/oui/pull/1422))

--- a/src/components/Badge/Badge.story.js
+++ b/src/components/Badge/Badge.story.js
@@ -24,6 +24,19 @@ stories
     <Badge color="plain">Plain</Badge>
     <Badge color="bad-news">Bad News</Badge>
   </div>))
+  .add('With Background Color', () => (<div>
+    <Badge backgroundColor="aqua">Aqua</Badge>
+    <Badge backgroundColor="yellow">Yellow</Badge>
+    <Badge backgroundColor="default">Default</Badge>
+    <Badge backgroundColor="green">Green</Badge>
+    <Badge backgroundColor="orange">Orange</Badge>
+    <Badge backgroundColor="pink">Pink</Badge>
+    <Badge backgroundColor="red">Red</Badge>
+    <Badge backgroundColor="magenta">Magenta</Badge>
+    <Badge backgroundColor="grey">Grey</Badge>
+    <Badge backgroundColor="purple">Purple</Badge>
+    <Badge backgroundColor="black">black</Badge>
+  </div>))
   .add('With text', (() => (<div className="flex flex-align--center">
     <Badge color="draft">1</Badge>{ text('text', 'Unpublished Change') }
   </div>)

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -2,28 +2,45 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import { FILL_COLOR_MAP } from '../../utils/accessibility';
+
 /**
  * Tiny inline component used to draw attention to an item's state or status.
  * @param {Object} props - Properties passed to component
  * @returns {ReactElement}
  */
-const Badge = (props) => {
+const Badge = ({
+  backgroundColor,
+  children,
+  color,
+  testSection,
+}) => {
   let classes = classNames({
     'oui-badge': true,
-    [`oui-badge--${props.color}`]: props.color,
+    [`oui-badge--${color}`]: color,
   });
+
+  // ensure valid backgroundColor name
+  // (in the case that propType errors are ignored)
+  const badgeFillColor =
+    backgroundColor && Object.keys(FILL_COLOR_MAP).includes(backgroundColor)
+      ? FILL_COLOR_MAP[backgroundColor]
+      : null;
 
   return (
     <span
       data-oui-component={ true }
       className={ classes }
-      data-test-section={ props.testSection }>
-      { props.children }
+      style={{ backgroundColor: badgeFillColor }}
+      data-test-section={ testSection }>
+      { children }
     </span>
   );
 };
 
 Badge.propTypes = {
+  /** Color to use for the background of the token */
+  backgroundColor: PropTypes.oneOf(Object.keys(FILL_COLOR_MAP)),
   /** Text that appears within the component */
   children: PropTypes.node.isRequired,
   /** Various color schemes */

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -22,10 +22,10 @@ const Badge = ({
 
   // ensure valid backgroundColor name
   // (in the case that propType errors are ignored)
-  const badgeFillColor =
-    backgroundColor && Object.keys(FILL_COLOR_MAP).includes(backgroundColor)
+  const badgeFillColor = backgroundColor && color === 'default'
+    && (Object.keys(FILL_COLOR_MAP).includes(backgroundColor)
       ? FILL_COLOR_MAP[backgroundColor]
-      : null;
+      : null);
 
   return (
     <span


### PR DESCRIPTION
## Summary
Added Background Color support to `Badge`. I needed a darker version of grey for a project, added support for Background color which can take these additional colors as `backgroundColor`.
1. aqua
2. yellow
3. green
4. orange
5. pink
6. red
7. magenta
8. grey
9. purple
10. black

## Changelog Entry

[Feature] Updated **Badge** with new `backgroundColor` to support additional colors.

## Test Plan
1. Manually tested thoroughly.
2. All existing unit tests pass.