### PR TITLE
performance (DragAndDrop) Memoize DraggableItem props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Patch] Memomized the **DraggableItem** props to increase re-render performance. ([#1425](https://github.com/optimizely/oui/pull/1425))
 
 ## 48.4.0 - 2020-09-24
 - [Feature] Updated **Badge** with new `backgroundColor` to support additional colors. ([#1423](https://github.com/optimizely/oui/pull/1423))

--- a/src/components/DragAndDrop/DraggableItem/index.js
+++ b/src/components/DragAndDrop/DraggableItem/index.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Draggable } from 'react-beautiful-dnd';
+import { isEqual, pick } from 'lodash';
 
 const DraggableItem = ({
   id,
@@ -50,4 +51,7 @@ DraggableItem.propTypes = {
 };
 
 
-export default DraggableItem;
+export default React.memo(DraggableItem, (prevProps, nextProps) => {
+  const deps = ['id', 'index', 'item', 'useCustomDragHandle'];
+  return isEqual(pick(prevProps, deps), pick(nextProps, deps));
+});


### PR DESCRIPTION
## Summary

When there's a list of draggle-items when should only re-render the items that need to get re-render.

Memoizing the draggable-items resulted in a noticeable increase in performance on our pages.

## Test Plan

I tested locally using `yarn link`

## Jira

- [APPX-2251](https://optimizely.atlassian.net/browse/APPX-2251)
